### PR TITLE
Using Task.Yield before MessageQueue.Send results in a performance improvement

### DIFF
--- a/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
@@ -40,7 +40,7 @@ namespace NServiceBus.Transport.Msmq
                 transportOperationTasks.Add(ExecuteTransportOperation(transaction, unicastTransportOperation));
             }
 
-            return Task.WhenAll(transportOperationTasks);
+            return transportOperationTasks.Count == 1 ? transportOperationTasks[0] : Task.WhenAll(transportOperationTasks);
         }
 
         async Task ExecuteTransportOperation(TransportTransaction transaction, UnicastTransportOperation transportOperation)

--- a/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.Transport.Msmq
             this.messageLabelGenerator = messageLabelGenerator;
         }
 
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
+        public async Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
         {
             Guard.AgainstNull(nameof(outgoingMessages), outgoingMessages);
 
@@ -33,12 +33,12 @@ namespace NServiceBus.Transport.Msmq
                 throw new Exception("The MSMQ transport only supports unicast transport operations.");
             }
 
+            await Task.Yield();
+
             foreach (var unicastTransportOperation in outgoingMessages.UnicastTransportOperations)
             {
                 ExecuteTransportOperation(transaction, unicastTransportOperation);
             }
-
-            return TaskEx.CompletedTask;
         }
 
         void ExecuteTransportOperation(TransportTransaction transaction, UnicastTransportOperation transportOperation)


### PR DESCRIPTION
Using `Task.Yield()` before `MessageQueue.Send` results in a significant performance improvement when doing lots of sends.

```c#
IMessageSession messageSession;
var numberOfMessages = 150000;
var tasks = new List<Task>(numberOfMessages);
for (var i = 0; i < numberOfMessages; i++)
{
    tasks.Add(messageSession.Send(new MyCommand()));
}
await Task.WhenAll(tasks).ConfigureAwait(false);
```
Transactional queues:

- Without Task.Yield: 3,498.31 msg/s
- With Task.Yield:12,793.95 msg/s

Non-transactional queues:

- Without Task.Yield: 4,288.47 msg/s
- With Task.Yield: 20,373.91 msg/s

This means that with the `Task.Yield` this executes more than 350% faster sends on transactional queues and 475% faster sends on non-transactional queues.

This PR has 2 commits, the first commit adds the `Task.Yield` to `MsmqMessageDispatcher.Dispatch`, meaning the transport operations as executed sequentially. The 2nd commit moves `Task.Yield` to `MsmqMessageDispatcher.ExecuteTransportOperation` and uses `Task.WhenAll` 

Original PR: https://github.com/Particular/NServiceBus/pull/4880