### PR TITLE
Throw an exception if Netbios name exceeds 15 characters

### DIFF
--- a/src/NServiceBus.Transport.Msmq/CheckMachineNameForCompliance.cs
+++ b/src/NServiceBus.Transport.Msmq/CheckMachineNameForCompliance.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Transport.Msmq
     using System.Runtime.InteropServices;
     using System.Text;
 
-    static class CheckMachineNameForComplianceWithDtcLimitation
+    static class CheckMachineNameForCompliance
     {
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         static extern bool GetComputerNameEx(COMPUTER_NAME_FORMAT nameType, [Out] StringBuilder lpBuffer, ref uint lpnSize);
@@ -25,7 +25,7 @@ namespace NServiceBus.Transport.Msmq
             {
                 return;
             }
-            throw new InvalidOperationException($"The NetBIOS name {netbiosName} is longer than 15 characters. Shorten the machine name to be 15 characters or less for MSMQ to be able to deliver messages.");
+            throw new InvalidOperationException($"The NetBIOS name {netbiosName} is longer than 15 characters. Shorten the machine name to 15 characters or less for MSMQ to deliver messages.");
         }
 
         enum COMPUTER_NAME_FORMAT

--- a/src/NServiceBus.Transport.Msmq/CheckMachineNameForCompliance.cs
+++ b/src/NServiceBus.Transport.Msmq/CheckMachineNameForCompliance.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Transport.Msmq
         static extern bool GetComputerNameEx(COMPUTER_NAME_FORMAT nameType, [Out] StringBuilder lpBuffer, ref uint lpnSize);
 
         /// <summary>
-        /// Method invoked to run custom code.
+        /// Checks to see if the NetBios computer name exceeds 15 characters and if so throws an exception.
         /// </summary>
         public static void Check()
         {
@@ -25,7 +25,7 @@ namespace NServiceBus.Transport.Msmq
             {
                 return;
             }
-            throw new InvalidOperationException($"The NetBIOS name {netbiosName} is longer than 15 characters. Shorten the machine name to 15 characters or less for MSMQ to deliver messages.");
+            throw new Exception($"The NetBIOS name {netbiosName} is longer than 15 characters. Shorten the machine name to 15 characters or less for MSMQ to deliver messages.");
         }
 
         enum COMPUTER_NAME_FORMAT

--- a/src/NServiceBus.Transport.Msmq/CheckMachineNameForComplianceWithDtcLimitation.cs
+++ b/src/NServiceBus.Transport.Msmq/CheckMachineNameForComplianceWithDtcLimitation.cs
@@ -1,10 +1,10 @@
 namespace NServiceBus.Transport.Msmq
 {
+    using System;
     using System.Runtime.InteropServices;
     using System.Text;
-    using Logging;
 
-    class CheckMachineNameForComplianceWithDtcLimitation
+    static class CheckMachineNameForComplianceWithDtcLimitation
     {
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         static extern bool GetComputerNameEx(COMPUTER_NAME_FORMAT nameType, [Out] StringBuilder lpBuffer, ref uint lpnSize);
@@ -12,7 +12,7 @@ namespace NServiceBus.Transport.Msmq
         /// <summary>
         /// Method invoked to run custom code.
         /// </summary>
-        public void Check()
+        public static void Check()
         {
             uint capacity = 24;
             var buffer = new StringBuilder((int) capacity);
@@ -25,11 +25,8 @@ namespace NServiceBus.Transport.Msmq
             {
                 return;
             }
-
-            Logger.WarnFormat("NetBIOS name [{0}] is longer than 15 characters. Shorten it for DTC to work.", netbiosName);
+            throw new InvalidOperationException($"The NetBIOS name {netbiosName} is longer than 15 characters. Shorten the machine name to be 15 characters or less for MSMQ to be able to deliver messages.");
         }
-
-        static ILog Logger = LogManager.GetLogger<CheckMachineNameForComplianceWithDtcLimitation>();
 
         enum COMPUTER_NAME_FORMAT
         {

--- a/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
@@ -77,7 +77,7 @@ namespace NServiceBus.Transport.Msmq
 
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
         {
-            new CheckMachineNameForComplianceWithDtcLimitation().Check();
+            CheckMachineNameForComplianceWithDtcLimitation.Check();
 
             // The following check avoids creating some sub-queues, if the endpoint sub queue has the capability to exceed the max length limitation for queue format name. 
             var bindings = settings.Get<QueueBindings>();
@@ -110,7 +110,7 @@ namespace NServiceBus.Transport.Msmq
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()
         {
-            new CheckMachineNameForComplianceWithDtcLimitation().Check();
+            CheckMachineNameForComplianceWithDtcLimitation.Check();
 
             if (!settings.TryGet("msmqLabelGenerator", out Func<IReadOnlyDictionary<string, string>, string> messageLabelGenerator))
             {

--- a/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
@@ -77,7 +77,7 @@ namespace NServiceBus.Transport.Msmq
 
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
         {
-            CheckMachineNameForComplianceWithDtcLimitation.Check();
+            CheckMachineNameForCompliance.Check();
 
             // The following check avoids creating some sub-queues, if the endpoint sub queue has the capability to exceed the max length limitation for queue format name. 
             var bindings = settings.Get<QueueBindings>();
@@ -110,7 +110,7 @@ namespace NServiceBus.Transport.Msmq
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()
         {
-            CheckMachineNameForComplianceWithDtcLimitation.Check();
+            CheckMachineNameForCompliance.Check();
 
             if (!settings.TryGet("msmqLabelGenerator", out Func<IReadOnlyDictionary<string, string>, string> messageLabelGenerator))
             {


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.Transport.Msmq/issues/14

NetBios name has to be 15 characters or less for MSMQ to work. 
See: http://geekswithblogs.net/Plumbersmate/archive/2012/02/03/make-sure-computer-names-are-15-characters-or-less-fro.aspx