### PR TITLE
Use wild cards for internal project dependencies

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-alpharelease0051" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
   </ItemGroup>
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TaskEx.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TaskEx.cs
@@ -1,0 +1,10 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System.Threading.Tasks;
+
+    static class TaskEx
+    {
+        //TODO: remove when we update to 4.6 and can use Task.CompletedTask
+        public static readonly Task CompletedTask = Task.FromResult(0);
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_TimeToBeReceived_set_and_ReceiveOnly.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_TimeToBeReceived_set_and_ReceiveOnly.cs
@@ -57,7 +57,7 @@
                 {
                     testContext.ReceivedTtbrMessage = true;
                     testContext.TimeToBeReceived = context.MessageHeaders[Headers.TimeToBeReceived];
-                    return Task.CompletedTask;
+                    return TaskEx.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -120,7 +120,7 @@
                         return context.Send(new RequestA());
                     }
 
-                    return Task.CompletedTask;
+                    return TaskEx.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_using_receive_only_transaction_level.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_using_receive_only_transaction_level.cs
@@ -72,7 +72,7 @@
                     {
                         testContext.ReceivedOutgoingMessage = true;
                     }
-                    return Task.CompletedTask;
+                    return TaskEx.CompletedTask;
                 }
             }
 

--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -13,14 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.0.0-beta0001" />
-    <PackageReference Include="NServiceBus.Testing.Fakes.Sources" Version="7.0.0-alpharelease0051" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus.Testing.Fakes.Sources" Version="7.0.0-*" />
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="PublicApiGenerator" Version="6.1.0-beta2" />
+    <PackageReference Include="PublicApiGenerator" Version="6.1.0-*" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-alpharelease0051" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-*" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <Reference Include="System.Messaging" />

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.0.0-beta0001" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.Transport.Msmq/issues/39

- Changed the NUnit3TestAdapter to use the same alpha version consistently
- Changed the .NET framework dependency to be 4.5.2 (as there is a conditional compile to avoid the serialization exception in the AcceptanceTest.cs)
- Introduced a temporary TaskEx.cs to allow Task.CompletedTask usage which can be removed when we move to 4.6.1