### PR TITLE
Use the endpoint name for the subscription storage queue name.

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store.cs
@@ -57,7 +57,8 @@
                         context.AddTrace("Subscriber1 is now subscribed");
                     });
                     b.DisableFeature<AutoSubscribe>();
-                    b.UsePersistence<MsmqPersistence>();
+                    var subscriptionsQueue = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)) + ".Subscriptions";
+                    b.UsePersistence<MsmqPersistence>().SubscriptionQueue(subscriptionsQueue);
                 });
             }
         }

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionPersistenceTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionPersistenceTests.cs
@@ -1,0 +1,42 @@
+﻿namespace NServiceBus.Transport.Msmq.Tests.Persistence
+{
+    using System;
+    using NServiceBus.Persistence.Msmq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MsmqSubscriptionPersistenceTests
+    {
+        [Test]
+        public void ShouldThrowIfOldDefaultSubscriptionQueuePresent()
+        {
+            // Create queue "NServiceBus.Subscriptions" to simulate the presence of the old default queue. 
+            const string oldDefaultQueue = "NServiceBus.Subscriptions";
+            var queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
+            MsmqHelpers.CreateQueue(queuePath);
+
+            var persistence = new MsmqSubscriptionPersistence();
+            Assert.IsTrue(persistence.DoesOldDefaultQueueExists());
+            Assert.Throws<Exception>(() => persistence.ThrowIfUsingTheOldDefaultSubscriptionsQueue(""));
+
+            // Delete the queue
+            MsmqHelpers.DeleteQueue(queuePath);
+        }
+
+        [Test]
+        public void ShouldNotThrowIfDefaultSubscriptionQueueIsConfigured()
+        {
+            // Create queue "NServiceBus.Subscriptions" to simulate the presence of the old default queue. 
+            const string oldDefaultQueue = "NServiceBus.Subscriptions";
+            var queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
+            MsmqHelpers.CreateQueue(queuePath);
+
+            var persistence = new MsmqSubscriptionPersistence();
+            Assert.IsTrue(persistence.DoesOldDefaultQueueExists());
+            Assert.DoesNotThrow(() => persistence.ThrowIfUsingTheOldDefaultSubscriptionsQueue("NServiceBus.Subscriptions"));
+
+            // Delete the queue
+            MsmqHelpers.DeleteQueue(queuePath);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionPersistenceTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionPersistenceTests.cs
@@ -3,42 +3,65 @@
     using System;
     using NServiceBus.Persistence.Msmq;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     public class MsmqSubscriptionPersistenceTests
     {
-        const string oldDefaultQueue = "NServiceBus.Subscriptions";
-
         [SetUp]
         public void Setup()
         {
-            // Create queue "NServiceBus.Subscriptions" to simulate the presence of the old default queue. 
-            var queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
+            // Create queue "NServiceBus.Subscriptions" to simulate the presence of the old default queue.
+            queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
             MsmqHelpers.CreateQueue(queuePath);
         }
 
         [TearDown]
         public void TearDown()
         {
-            var queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
             // Delete the queue
             MsmqHelpers.DeleteQueue(queuePath);
         }
 
         [Test]
-        public void ShouldThrowIfOldDefaultSubscriptionQueuePresent()
+        public void ShouldThrowIfStorageQueueNotConfiguredAndOldDefaultIsPresent()
         {
-            var persistence = new MsmqSubscriptionPersistence();
-            Assert.IsTrue(persistence.DoesOldDefaultQueueExists());
-            Assert.Throws<Exception>(() => persistence.ThrowIfUsingTheOldDefaultSubscriptionsQueue(""));
+            Assert.Throws<Exception>(() => MsmqSubscriptionPersistence.DetermineStorageQueueName(PrepareSettings(configuredStorageQueueName: null)));
         }
 
         [Test]
-        public void ShouldNotThrowIfDefaultSubscriptionQueueIsConfigured()
+        public void ShouldUseConfiguredStorageQueueEvenIfOldDefaultIsPresent()
         {
-            var persistence = new MsmqSubscriptionPersistence();
-            Assert.IsTrue(persistence.DoesOldDefaultQueueExists());
-            Assert.DoesNotThrow(() => persistence.ThrowIfUsingTheOldDefaultSubscriptionsQueue("NServiceBus.Subscriptions"));
+            const string customStorageQueue = "MyStorageQueue";
+
+            Assert.AreEqual(customStorageQueue, MsmqSubscriptionPersistence.DetermineStorageQueueName(PrepareSettings(configuredStorageQueueName: customStorageQueue)));
         }
+
+        [Test]
+        public void ShouldDefaultStorageQueueIfNotConfiguredAndNoOldLegacyQueueIsPresent()
+        {
+            const string endpointName = "MyEndpoint";
+
+            MsmqHelpers.DeleteQueue(queuePath);
+
+            Assert.AreEqual($"{endpointName}.Subscriptions", MsmqSubscriptionPersistence.DetermineStorageQueueName(PrepareSettings(endpointName)));
+        }
+
+        static ReadOnlySettings PrepareSettings(string endpointName = "DefaultEndpoint", string configuredStorageQueueName = null)
+        {
+            var settings = new SettingsHolder();
+
+            settings.Set("NServiceBus.Routing.EndpointName", endpointName);
+
+            if (!string.IsNullOrEmpty(configuredStorageQueueName))
+            {
+                settings.Set(MsmqSubscriptionStorageConfigurationExtensions.MsmqPersistenceQueueConfigurationKey, configuredStorageQueueName);
+            }
+
+            return settings;
+        }
+
+        string queuePath;
+        const string oldDefaultQueue = "NServiceBus.Subscriptions";
     }
 }

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionPersistenceTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionPersistenceTests.cs
@@ -7,36 +7,38 @@
     [TestFixture]
     public class MsmqSubscriptionPersistenceTests
     {
-        [Test]
-        public void ShouldThrowIfOldDefaultSubscriptionQueuePresent()
+        const string oldDefaultQueue = "NServiceBus.Subscriptions";
+
+        [SetUp]
+        public void Setup()
         {
             // Create queue "NServiceBus.Subscriptions" to simulate the presence of the old default queue. 
-            const string oldDefaultQueue = "NServiceBus.Subscriptions";
             var queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
             MsmqHelpers.CreateQueue(queuePath);
+        }
 
-            var persistence = new MsmqSubscriptionPersistence();
-            Assert.IsTrue(persistence.DoesOldDefaultQueueExists());
-            Assert.Throws<Exception>(() => persistence.ThrowIfUsingTheOldDefaultSubscriptionsQueue(""));
-
+        [TearDown]
+        public void TearDown()
+        {
+            var queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
             // Delete the queue
             MsmqHelpers.DeleteQueue(queuePath);
         }
 
         [Test]
+        public void ShouldThrowIfOldDefaultSubscriptionQueuePresent()
+        {
+            var persistence = new MsmqSubscriptionPersistence();
+            Assert.IsTrue(persistence.DoesOldDefaultQueueExists());
+            Assert.Throws<Exception>(() => persistence.ThrowIfUsingTheOldDefaultSubscriptionsQueue(""));
+        }
+
+        [Test]
         public void ShouldNotThrowIfDefaultSubscriptionQueueIsConfigured()
         {
-            // Create queue "NServiceBus.Subscriptions" to simulate the presence of the old default queue. 
-            const string oldDefaultQueue = "NServiceBus.Subscriptions";
-            var queuePath = MsmqAddress.Parse(oldDefaultQueue).PathWithoutPrefix;
-            MsmqHelpers.CreateQueue(queuePath);
-
             var persistence = new MsmqSubscriptionPersistence();
             Assert.IsTrue(persistence.DoesOldDefaultQueueExists());
             Assert.DoesNotThrow(() => persistence.ThrowIfUsingTheOldDefaultSubscriptionsQueue("NServiceBus.Subscriptions"));
-
-            // Delete the queue
-            MsmqHelpers.DeleteQueue(queuePath);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageIntegrationTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageIntegrationTests.cs
@@ -1,10 +1,10 @@
-﻿namespace NServiceBus.Transport.Msmq.Tests
+﻿namespace NServiceBus.Transport.Msmq.Tests.Persistence
 {
     using System.Messaging;
     using System.Threading.Tasks;
     using Extensibility;
+    using NServiceBus.Persistence.Msmq;
     using NUnit.Framework;
-    using Persistence.Msmq;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
     using MessageType = Unicast.Subscriptions.MessageType;
 

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
@@ -1,12 +1,12 @@
-﻿namespace NServiceBus.Transport.Msmq.Tests
+﻿namespace NServiceBus.Transport.Msmq.Tests.Persistence
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Extensibility;
+    using NServiceBus.Persistence.Msmq;
     using NUnit.Framework;
-    using Persistence.Msmq;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
     using MessageType = Unicast.Subscriptions.MessageType;
 

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -26,7 +26,7 @@
                 }
 
                 var defaultQueueName = $"{context.Settings.EndpointName()}.Subscriptions";
-                Logger.Warn($"The queue used to store subscriptions has not been configured, the default '{defaultQueueName}' will be used.");
+                Logger.Info($"The queue used to store subscriptions has not been configured, the default '{defaultQueueName}' will be used.");
                 configuredQueueName = defaultQueueName;
             }
 
@@ -56,7 +56,7 @@
                     // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue. 
                     // Indicates that the endoint was using old default queue name.
                     throw new Exception(
-                        "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. The new default is now `[Your endpointname].Subscriptions`. Move the relevant subscription messages to the new queue or configure the subscriptions queue name.");
+                        "Detected the presence of an old default queue named NServiceBus.Subscriptions. Either migrate the subscriptions to the new default queue [Your endpointname].Subscriptions, see our documentation for more details, or explicitly configure the subscriptions queue name to `NServiceBus.Subscriptions` if you want to use the existing queue.");
                 }
             }
         }

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Persistence.Msmq
 {
+    using System;
+    using System.Messaging;
     using Features;
     using Logging;
     using Transport;
@@ -9,15 +11,24 @@
     {
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var queueName = context.Settings.GetConfiguredMsmqPersistenceSubscriptionQueue();
+            var configuredQueueName = context.Settings.GetConfiguredMsmqPersistenceSubscriptionQueue();
 
-            if (string.IsNullOrEmpty(queueName))
+            if (string.IsNullOrEmpty(configuredQueueName))
             {
-                queueName = $"{context.Settings.EndpointName()}.Subscriptions";
-                Logger.Warn($"The queue used to store subscriptions has not been configured, so the default '{queueName}' will be used.");
+                if (DoesOldDefaultQueueExists())
+                {
+                    // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue. 
+                    // Indicates that the endoint was using old default queue name.
+                    throw new Exception(
+                        "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. The new default is now `[Your endpointname].Subscriptions`. Move the messages to the new queue or configure the subscriptions queue name.");
+                }
+
+                var defaultQueueName = $"{context.Settings.EndpointName()}.Subscriptions";
+                Logger.Warn($"The queue used to store subscriptions has not been configured, so the default '{defaultQueueName}' will be used.");
+                configuredQueueName = defaultQueueName;
             }
 
-            context.Settings.Get<QueueBindings>().BindSending(queueName);
+            context.Settings.Get<QueueBindings>().BindSending(configuredQueueName);
 
             var useTransactionalStorageQueue = true;
             MsmqSettings msmqSettings;
@@ -29,9 +40,16 @@
 
             context.Container.ConfigureComponent(b =>
             {
-                var queue = new MsmqSubscriptionStorageQueue(MsmqAddress.Parse(queueName), useTransactionalStorageQueue);
+                var queue = new MsmqSubscriptionStorageQueue(MsmqAddress.Parse(configuredQueueName), useTransactionalStorageQueue);
                 return new MsmqSubscriptionStorage(queue);
             }, DependencyLifecycle.SingleInstance);
+        }
+
+        bool DoesOldDefaultQueueExists()
+        {
+            const string oldDefaultSubscriptionsQueue = "NServiceBus.Subscriptions";
+            var path = MsmqAddress.Parse(oldDefaultSubscriptionsQueue).PathWithoutPrefix;
+            return MessageQueue.Exists(path);
         }
 
         static ILog Logger = LogManager.GetLogger(typeof(MsmqSubscriptionPersistence));

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -13,7 +13,7 @@
 
             if (string.IsNullOrEmpty(queueName))
             {
-                queueName = "NServiceBus.Subscriptions";
+                queueName = $"{context.Settings.EndpointName()}.Subscriptions";
                 Logger.Warn($"The queue used to store subscriptions has not been configured, so the default '{queueName}' will be used.");
             }
 

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -4,6 +4,7 @@
     using System.Messaging;
     using Features;
     using Logging;
+    using Settings;
     using Transport;
     using Transport.Msmq;
 
@@ -11,31 +12,13 @@
     {
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var configuredQueueName = context.Settings.GetConfiguredMsmqPersistenceSubscriptionQueue();
-
-            ThrowIfUsingTheOldDefaultSubscriptionsQueue(configuredQueueName);
-
-            if (string.IsNullOrEmpty(configuredQueueName))
-            {
-                if (DoesOldDefaultQueueExists())
-                {
-                    // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue. 
-                    // Indicates that the endoint was using old default queue name.
-                    throw new Exception(
-                        "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. The new default is now `[Your endpointname].Subscriptions`. Move the relevant subscription messages to the new queue or configure the subscriptions queue name.");
-                }
-
-                var defaultQueueName = $"{context.Settings.EndpointName()}.Subscriptions";
-                Logger.Info($"The queue used to store subscriptions has not been configured, the default '{defaultQueueName}' will be used.");
-                configuredQueueName = defaultQueueName;
-            }
+            var configuredQueueName = DetermineStorageQueueName(context.Settings);
 
             context.Settings.Get<QueueBindings>().BindSending(configuredQueueName);
 
             var useTransactionalStorageQueue = true;
-            MsmqSettings msmqSettings;
 
-            if (context.Settings.TryGet(out msmqSettings))
+            if (context.Settings.TryGet<MsmqSettings>(out var msmqSettings))
             {
                 useTransactionalStorageQueue = msmqSettings.UseTransactionalQueues;
             }
@@ -47,21 +30,33 @@
             }, DependencyLifecycle.SingleInstance);
         }
 
-        internal void ThrowIfUsingTheOldDefaultSubscriptionsQueue(string configuredQueueName)
+        internal static string DetermineStorageQueueName(ReadOnlySettings settings)
         {
+            var configuredQueueName = settings.GetConfiguredMsmqPersistenceSubscriptionQueue();
+
             if (string.IsNullOrEmpty(configuredQueueName))
             {
-                if (DoesOldDefaultQueueExists())
-                {
-                    // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue. 
-                    // Indicates that the endoint was using old default queue name.
-                    throw new Exception(
-                        "Detected the presence of an old default queue named NServiceBus.Subscriptions. Either migrate the subscriptions to the new default queue [Your endpointname].Subscriptions, see our documentation for more details, or explicitly configure the subscriptions queue name to `NServiceBus.Subscriptions` if you want to use the existing queue.");
-                }
+                ThrowIfUsingTheOldDefaultSubscriptionsQueue(configuredQueueName);
+
+                var defaultQueueName = $"{settings.EndpointName()}.Subscriptions";
+                Logger.Info($"The queue used to store subscriptions has not been configured, the default '{defaultQueueName}' will be used.");
+                configuredQueueName = defaultQueueName;
+            }
+            return configuredQueueName;
+        }
+
+        static void ThrowIfUsingTheOldDefaultSubscriptionsQueue(string configuredQueueName)
+        {
+            if (DoesOldDefaultQueueExists())
+            {
+                // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue.
+                // Indicates that the endpoint was using old default queue name.
+                throw new Exception(
+                    "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. Either migrate the subscriptions to the new default queue `[Your endpoint name].Subscriptions`, see our documentation for more details, or explicitly configure the subscriptions queue name to `NServiceBus.Subscriptions` if you want to use the existing queue.");
             }
         }
 
-        internal bool DoesOldDefaultQueueExists()
+        static bool DoesOldDefaultQueueExists()
         {
             const string oldDefaultSubscriptionsQueue = "NServiceBus.Subscriptions";
             var path = MsmqAddress.Parse(oldDefaultSubscriptionsQueue).PathWithoutPrefix;

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -20,11 +20,11 @@
                     // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue. 
                     // Indicates that the endoint was using old default queue name.
                     throw new Exception(
-                        "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. The new default is now `[Your endpointname].Subscriptions`. Move the messages to the new queue or configure the subscriptions queue name.");
+                        "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. The new default is now `[Your endpointname].Subscriptions`. Move the relevant subscription messages to the new queue or configure the subscriptions queue name.");
                 }
 
                 var defaultQueueName = $"{context.Settings.EndpointName()}.Subscriptions";
-                Logger.Warn($"The queue used to store subscriptions has not been configured, so the default '{defaultQueueName}' will be used.");
+                Logger.Warn($"The queue used to store subscriptions has not been configured, the default '{defaultQueueName}' will be used.");
                 configuredQueueName = defaultQueueName;
             }
 

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorageConfigurationExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorageConfigurationExtensions.cs
@@ -19,14 +19,14 @@
             Guard.AgainstNull(nameof(persistenceExtensions), persistenceExtensions);
             Guard.AgainstNull(nameof(queue), queue);
 
-            persistenceExtensions.GetSettings().Set(msmqPersistenceQueueConfigurationKey, queue);
+            persistenceExtensions.GetSettings().Set(MsmqPersistenceQueueConfigurationKey, queue);
         }
 
         internal static string GetConfiguredMsmqPersistenceSubscriptionQueue(this ReadOnlySettings settings)
         {
-            return settings.GetOrDefault<string>(msmqPersistenceQueueConfigurationKey);
+            return settings.GetOrDefault<string>(MsmqPersistenceQueueConfigurationKey);
         }
 
-        const string msmqPersistenceQueueConfigurationKey = "MsmqSubscriptionPersistence.QueueName";
+        internal const string MsmqPersistenceQueueConfigurationKey = "MsmqSubscriptionPersistence.QueueName";
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.Transport.Msmq/issues/46