### PR TITLE
New default for subscription queue improvements

### DIFF
--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -45,18 +45,18 @@
             return configuredQueueName;
         }
 
-        internal static void ThrowIfUsingTheOldDefaultSubscriptionsQueue(string configuredQueueName)
+        static void ThrowIfUsingTheOldDefaultSubscriptionsQueue(string configuredQueueName)
         {
             if (DoesOldDefaultQueueExists())
             {
                 // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue.
                 // Indicates that the endpoint was using old default queue name.
                 throw new Exception(
-                    "Detected the presence of an old default queue named NServiceBus.Subscriptions. Either migrate the subscriptions to the new default queue `[Your endpoint name].Subscriptions`, see our documentation for more details, or explicitly configure the subscriptions queue name to `NServiceBus.Subscriptions` if you want to use the existing queue.");
+                    "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. Either migrate the subscriptions to the new default queue `[Your endpoint name].Subscriptions`, see our documentation for more details, or explicitly configure the subscriptions queue name to `NServiceBus.Subscriptions` if you want to use the existing queue.");
             }
         }
 
-        internal static bool DoesOldDefaultQueueExists()
+        static bool DoesOldDefaultQueueExists()
         {
             const string oldDefaultSubscriptionsQueue = "NServiceBus.Subscriptions";
             var path = MsmqAddress.Parse(oldDefaultSubscriptionsQueue).PathWithoutPrefix;

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -4,6 +4,7 @@
     using System.Messaging;
     using Features;
     using Logging;
+    using Settings;
     using Transport;
     using Transport.Msmq;
 
@@ -11,31 +12,13 @@
     {
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var configuredQueueName = context.Settings.GetConfiguredMsmqPersistenceSubscriptionQueue();
-
-            ThrowIfUsingTheOldDefaultSubscriptionsQueue(configuredQueueName);
-
-            if (string.IsNullOrEmpty(configuredQueueName))
-            {
-                if (DoesOldDefaultQueueExists())
-                {
-                    // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue. 
-                    // Indicates that the endoint was using old default queue name.
-                    throw new Exception(
-                        "Detected the presence of an old default queue named `NServiceBus.Subscriptions`. The new default is now `[Your endpointname].Subscriptions`. Move the relevant subscription messages to the new queue or configure the subscriptions queue name.");
-                }
-
-                var defaultQueueName = $"{context.Settings.EndpointName()}.Subscriptions";
-                Logger.Info($"The queue used to store subscriptions has not been configured, the default '{defaultQueueName}' will be used.");
-                configuredQueueName = defaultQueueName;
-            }
+            var configuredQueueName = DetermineStorageQueueName(context.Settings);
 
             context.Settings.Get<QueueBindings>().BindSending(configuredQueueName);
 
             var useTransactionalStorageQueue = true;
-            MsmqSettings msmqSettings;
 
-            if (context.Settings.TryGet(out msmqSettings))
+            if (context.Settings.TryGet<MsmqSettings>(out var msmqSettings))
             {
                 useTransactionalStorageQueue = msmqSettings.UseTransactionalQueues;
             }
@@ -47,21 +30,33 @@
             }, DependencyLifecycle.SingleInstance);
         }
 
-        internal void ThrowIfUsingTheOldDefaultSubscriptionsQueue(string configuredQueueName)
+        internal static string DetermineStorageQueueName(ReadOnlySettings settings)
         {
+            var configuredQueueName = settings.GetConfiguredMsmqPersistenceSubscriptionQueue();
+
             if (string.IsNullOrEmpty(configuredQueueName))
             {
-                if (DoesOldDefaultQueueExists())
-                {
-                    // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue. 
-                    // Indicates that the endoint was using old default queue name.
-                    throw new Exception(
-                        "Detected the presence of an old default queue named NServiceBus.Subscriptions. Either migrate the subscriptions to the new default queue [Your endpointname].Subscriptions, see our documentation for more details, or explicitly configure the subscriptions queue name to `NServiceBus.Subscriptions` if you want to use the existing queue.");
-                }
+                ThrowIfUsingTheOldDefaultSubscriptionsQueue(configuredQueueName);
+
+                var defaultQueueName = $"{settings.EndpointName()}.Subscriptions";
+                Logger.Info($"The queue used to store subscriptions has not been configured, the default '{defaultQueueName}' will be used.");
+                configuredQueueName = defaultQueueName;
+            }
+            return configuredQueueName;
+        }
+
+        internal static void ThrowIfUsingTheOldDefaultSubscriptionsQueue(string configuredQueueName)
+        {
+            if (DoesOldDefaultQueueExists())
+            {
+                // The user has not configured the subscriptions queue to be "NServiceBus.Subscriptions" but there's a local queue.
+                // Indicates that the endpoint was using old default queue name.
+                throw new Exception(
+                    "Detected the presence of an old default queue named NServiceBus.Subscriptions. Either migrate the subscriptions to the new default queue `[Your endpoint name].Subscriptions`, see our documentation for more details, or explicitly configure the subscriptions queue name to `NServiceBus.Subscriptions` if you want to use the existing queue.");
             }
         }
 
-        internal bool DoesOldDefaultQueueExists()
+        internal static bool DoesOldDefaultQueueExists()
         {
             const string oldDefaultSubscriptionsQueue = "NServiceBus.Subscriptions";
             var path = MsmqAddress.Parse(oldDefaultSubscriptionsQueue).PathWithoutPrefix;

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorageConfigurationExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorageConfigurationExtensions.cs
@@ -19,14 +19,14 @@
             Guard.AgainstNull(nameof(persistenceExtensions), persistenceExtensions);
             Guard.AgainstNull(nameof(queue), queue);
 
-            persistenceExtensions.GetSettings().Set(msmqPersistenceQueueConfigurationKey, queue);
+            persistenceExtensions.GetSettings().Set(MsmqPersistenceQueueConfigurationKey, queue);
         }
 
         internal static string GetConfiguredMsmqPersistenceSubscriptionQueue(this ReadOnlySettings settings)
         {
-            return settings.GetOrDefault<string>(msmqPersistenceQueueConfigurationKey);
+            return settings.GetOrDefault<string>(MsmqPersistenceQueueConfigurationKey);
         }
 
-        const string msmqPersistenceQueueConfigurationKey = "MsmqSubscriptionPersistence.QueueName";
+        internal const string MsmqPersistenceQueueConfigurationKey = "MsmqSubscriptionPersistence.QueueName";
     }
 }


### PR DESCRIPTION
@indualagarsamy there was some redundant code to detect and throw when the old default existed so I took the liberty to clean that up.

I also added a test to verify the new default name.

What do you think?