### PR TITLE
Minor fixups

### DIFF
--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.Testing.Fakes.Sources" Version="7.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="PublicApiGenerator" Version="8.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.Testing.Fakes.Sources" Version="7.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="PublicApiGenerator" Version="8.0.0" />
+    <PackageReference Include="PublicApiGenerator" Version="6.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -7,7 +7,7 @@
     <OutputPath>..\..\binaries\</OutputPath>
     <Description>MSMQ support for NServiceBus</Description>
     <!-- Disable NU5111 and NU5110 as CreateQueues.ps1 and DeleteQueues.ps1 scripts are intentionally not put into the tools folder. -->
-    <NoWarn>NU5110,NU5111</NoWarn>
+    <NoWarn>$(NoWarn);NU5110;NU5111</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some fixups from #65:
* Fix usage of `NoWarn`
* Keep NUnitTestAdapter and the PublicApiGenerator packages on the old version for .net core compatibility. While the current versions runs fine in VS & TC, it can cause issues when running it via dotnet commands due to Mono.Cecil issues.