### PR TITLE
Hotfix 1.0.1

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -13,10 +13,11 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
         queueBindings = configuration.GetSettings().Get<QueueBindings>();
-     
+
         var transportConfig = configuration.UseTransport<MsmqTransport>();
         transportConfig.DisableConnectionCachingForSends();
-        
+        configuration.GetSettings().Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
+
         var routingConfig = transportConfig.Routing();
 
         foreach (var publisher in publisherMetadata.Publishers)

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqMessagePumpTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqMessagePumpTests.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Transport.Msmq.Tests
         [Test]
         public void ShouldThrowIfConfiguredToReceiveFromRemoteQueue()
         {
-            var messagePump = new MessagePump(mode => null);
+            var messagePump = new MessagePump(mode => null, TimeSpan.Zero);
             var pushSettings = new PushSettings("queue@remote", "error", false, TransportTransactionMode.None);
 
             var exception = Assert.Throws<Exception>(() =>

--- a/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
@@ -14,6 +14,7 @@ class ConfigureMsmqTransportInfrastructure : IConfigureTransportInfrastructure
     {
         var msmqTransportDefinition = new MsmqTransport();
         settingsHolder = settings;
+        settingsHolder.Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
         return new TransportConfigurationResult
         {
             TransportInfrastructure = msmqTransportDefinition.Initialize(settingsHolder, null),

--- a/src/NServiceBus.Transport.Msmq/MessagePump.cs
+++ b/src/NServiceBus.Transport.Msmq/MessagePump.cs
@@ -13,9 +13,10 @@ namespace NServiceBus.Transport.Msmq
 
     class MessagePump : IPushMessages, IDisposable
     {
-        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory)
+        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory, TimeSpan messageEnumeratorTimeout)
         {
             this.receiveStrategyFactory = receiveStrategyFactory;
+            this.messageEnumeratorTimeout = messageEnumeratorTimeout;
         }
 
         public void Dispose()
@@ -125,7 +126,7 @@ namespace NServiceBus.Transport.Msmq
                     try
                     {
                         //note: .Peek will throw an ex if no message is available. It also turns out that .MoveNext is faster since message isn't read
-                        if (!enumerator.MoveNext(TimeSpan.FromMilliseconds(10)))
+                        if (!enumerator.MoveNext(messageEnumeratorTimeout))
                         {
                             continue;
                         }
@@ -230,6 +231,7 @@ namespace NServiceBus.Transport.Msmq
         RepeatedFailuresOverTimeCircuitBreaker peekCircuitBreaker;
         RepeatedFailuresOverTimeCircuitBreaker receiveCircuitBreaker;
         Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory;
+        TimeSpan messageEnumeratorTimeout;
         ConcurrentDictionary<Task, Task> runningReceiveTasks;
 
         static ILog Logger = LogManager.GetLogger<MessagePump>();

--- a/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
@@ -19,6 +19,7 @@ namespace NServiceBus.Transport.Msmq
             TimeToReachQueue = Message.InfiniteTimeout;
             ScopeOptions = new MsmqScopeOptions();
             LabelGenerator = (headers => string.Empty);
+            MessageEnumeratorTimeout = TimeSpan.FromSeconds(1); //with a 1s timeout a graceful shutdown will take on average 500ms which is acceptable
 
             if (settings == null)
             {
@@ -48,6 +49,11 @@ namespace NServiceBus.Transport.Msmq
             if (settings.TryGet<TimeSpan>("TimeToReachQueue", out var timeToReachQueue))
             {
                 TimeToReachQueue = timeToReachQueue;
+            }
+
+            if (settings.TryGet<TimeSpan>("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", out var messageEnumeratorTimeout))
+            {
+                MessageEnumeratorTimeout = messageEnumeratorTimeout;
             }
 
             if (settings.TryGet<bool>("UseDeadLetterQueueForMessagesWithTimeToBeReceived", out var useDeadLetterQueueForMessagesWithTimeToBeReceived))
@@ -83,5 +89,7 @@ namespace NServiceBus.Transport.Msmq
         public MsmqScopeOptions ScopeOptions { get; set; }
 
         public Func<IReadOnlyDictionary<string, string>, string> LabelGenerator { get; set; }
+
+        public TimeSpan MessageEnumeratorTimeout { get; set; }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
@@ -90,7 +90,7 @@ namespace NServiceBus.Transport.Msmq
             }
 
             return new TransportReceiveInfrastructure(
-                () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, msmqSettings.ScopeOptions.TransactionOptions)),
+                () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, msmqSettings.ScopeOptions.TransactionOptions), msmqSettings.MessageEnumeratorTimeout),
                 () =>
                 {
                     if (msmqSettings.ExecuteInstaller)


### PR DESCRIPTION
Fixes #77 

- Increasing the default value from 10ms to 1 second. 
- Adds a new configuration setting called `NServiceBus.Transport.Msmq.MessageEnumeratorTimeout`,  that can be set to adjust this value if needed. 
- Increasing this value means that the amount of time to see if there are messages in the queue is increased, so this will approximately the same amount of time that the endpoint will wait before it can be shut down. So, for example a 5second value might delay the shutting down of the endpoint by approximately 3s to 5s.  

Note that this PR should not be squashed