### PR TITLE
Stop leaking headers

### DIFF
--- a/src/NServiceBus.Transport.Msmq/NoTransactionStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/NoTransactionStrategy.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.Transport.Msmq
                 {
                     message.BodyStream.Position = 0;
 
-                    await HandleError(message, headers, exception, transportTransaction, 1).ConfigureAwait(false);
+                    await HandleError(message, MsmqUtilities.ExtractHeaders(message), exception, transportTransaction, 1).ConfigureAwait(false);
                 }
             }
         }

--- a/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
@@ -117,7 +117,7 @@ namespace NServiceBus.Transport.Msmq
             try
             {
                 var body = await ReadStream(message.BodyStream).ConfigureAwait(false);
-                var errorContext = new ErrorContext(exception, headers, message.Id, body, transportTransaction, processingAttempts);
+                var errorContext = new ErrorContext(exception, new Dictionary<string, string>(headers), message.Id, body, transportTransaction, processingAttempts);
 
                 return await onError(errorContext).ConfigureAwait(false);
             }
@@ -133,7 +133,7 @@ namespace NServiceBus.Transport.Msmq
         static async Task<byte[]> ReadStream(Stream bodyStream)
         {
             bodyStream.Seek(0, SeekOrigin.Begin);
-            var length = (int) bodyStream.Length;
+            var length = (int)bodyStream.Length;
             var body = new byte[length];
             await bodyStream.ReadAsync(body, 0, length).ConfigureAwait(false);
             return body;


### PR DESCRIPTION
Only copies headers when things fail so this should not impact performance for successful processing

Aligns the transport with the behaviour expected by https://github.com/Particular/NServiceBus/pull/5353

Fixes https://github.com/Particular/NServiceBus.Transport.Msmq/issues/68