### PR TITLE
Dynatrace causes header corruption which results in failed 

### DIFF
--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
@@ -138,12 +138,10 @@
         {
             var expected = "Hello World";
 
-            Console.Out.WriteLine(sizeof(char));
             var message = MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>
             {
                 {"NServiceBus.ExceptionInfo.Message", expected}
             }, new byte[0]), new List<DeliveryConstraint>());
-
 
             var r = new Random();
 

--- a/src/NServiceBus.Transport.Msmq/ByteArrayExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/ByteArrayExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+static class ByteArrayExtensions
+{
+    public static int LastIndexOf(this byte[] data, byte[] pattern)
+    {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        if (pattern == null) throw new ArgumentNullException(nameof(pattern));
+        if (pattern.Length > data.Length) return -1;
+
+        int cycles = data.Length - pattern.Length + 1;
+        int patternIndex;
+        for (int dataIndex = cycles; dataIndex > 0; dataIndex--)
+        {
+            if (data[dataIndex] != pattern[0]) continue;
+            for (patternIndex = pattern.Length - 1; patternIndex >= 1; patternIndex--) if (data[dataIndex + patternIndex] != pattern[patternIndex]) break;
+            if (patternIndex == 0) return dataIndex;
+        }
+        return -1;
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/ByteArrayExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/ByteArrayExtensions.cs
@@ -8,11 +8,11 @@ static class ByteArrayExtensions
         if (pattern == null) throw new ArgumentNullException(nameof(pattern));
         if (pattern.Length > data.Length) return -1;
 
-        int cycles = data.Length - pattern.Length + 1;
-        int patternIndex;
-        for (int dataIndex = cycles; dataIndex > 0; dataIndex--)
+        var cycles = data.Length - pattern.Length + 1;
+        for (var dataIndex = cycles; dataIndex > 0; dataIndex--)
         {
             if (data[dataIndex] != pattern[0]) continue;
+            int patternIndex;
             for (patternIndex = pattern.Length - 1; patternIndex >= 1; patternIndex--) if (data[dataIndex + patternIndex] != pattern[patternIndex]) break;
             if (patternIndex == 0) return dataIndex;
         }

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -91,9 +91,10 @@ namespace NServiceBus.Transport.Msmq
 
             //This is to make us compatible with v3 messages that are affected by this bug:
             //http://stackoverflow.com/questions/3779690/xml-serialization-appending-the-0-backslash-0-or-null-character
-            var extension = Encoding.UTF8.GetString(m.Extension).TrimEnd('\0');
+            var data = m.Extension;
+            var xmlLength = data.LastIndexOf(EndTag) + EndTag.Length; // Ignore any data after last </ArrayOfHeaderInfo>
             object o;
-            using (var stream = new StringReader(extension))
+            using (var stream = new MemoryStream(buffer: data, index: 0, count: xmlLength, writable: false, publiclyVisible: true))
             {
                 using (var reader = XmlReader.Create(stream, new XmlReaderSettings
                 {
@@ -215,5 +216,6 @@ namespace NServiceBus.Transport.Msmq
 
         static System.Xml.Serialization.XmlSerializer headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
         static ILog Logger = LogManager.GetLogger<MsmqUtilities>();
+        static byte[] EndTag = Encoding.UTF8.GetBytes("</ArrayOfHeaderInfo>");
     }
 }


### PR DESCRIPTION
Based on user report Dynatrace can add binary data to the MSMQ Message extension which already contains data serialized by NServiceBus. By ignoring everything after the last `</ArrayOfHeaderInfo>` tag this binary data does not affect header deserialization and preventing messages to be treated as POISON messages.

```
System.InvalidOperationException: There is an error in XML document (31, 21). ---> System.Xml.XmlException: '.', hexadecimal value 0x00, is an invalid character. Line 31, position 21.
```

Existing code was already stripping trailing null's and was doing an inefficient byte array to string to Stream conversion. This change does "last index" but after that efficiently creates a MemoryStream preventing the string creation.

This change is to apply the Robustness principle and be liberal in what to accept.