### PR TITLE
Validating transaction isolation level for unsupported values during configuration

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
 {
+    using System;
     using System.Threading.Tasks;
     using System.Transactions;
     using AcceptanceTesting;
@@ -10,17 +11,53 @@
     public class When_customizing_scope_isolation_level : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_honor_configured_level()
+        [TestCase(IsolationLevel.Chaos)]
+        [TestCase(IsolationLevel.ReadCommitted)]
+        [TestCase(IsolationLevel.ReadUncommitted)]
+        [TestCase(IsolationLevel.RepeatableRead)]
+        [TestCase(IsolationLevel.Serializable)]
+        public async Task Should_honor_configured_level(IsolationLevel isolationLevel)
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<ScopeEndpoint>(g => g.When(b => b.SendLocal(new MyMessage())))
+                    .WithEndpoint<ScopeEndpoint>(g =>
+                    {
+                        g.CustomConfig(c =>
+                        {
+                            c.UseTransport<MsmqTransport>()
+                                .Transactions(TransportTransactionMode.TransactionScope)
+                                .TransactionScopeOptions(isolationLevel: isolationLevel);
+                        });
+                        g.When(b => b.SendLocal(new MyMessage()));
+                    })
                     .Done(c => c.Done)
                     .Run();
 
             Assert.True(context.AmbientTransactionPresent, "There should be a ambient transaction present");
-            Assert.AreEqual(context.IsolationLevel, IsolationLevel.RepeatableRead, "There should be a ambient transaction present");
+            Assert.AreEqual(context.IsolationLevel, isolationLevel, "There should be a ambient transaction present");
         }
 
+        [Test]
+        public void Should_fail_for_snapshot()
+        {
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                var context = await Scenario.Define<Context>()
+                        .WithEndpoint<ScopeEndpoint>(g =>
+                        {
+                            g.CustomConfig(c =>
+                            {
+                                c.UseTransport<MsmqTransport>()
+                                    .Transactions(TransportTransactionMode.TransactionScope)
+                                    .TransactionScopeOptions(isolationLevel: IsolationLevel.Snapshot);
+                            });
+                            g.When(b => b.SendLocal(new MyMessage()));
+                        })
+                        .Done(c => c.Done)
+                        .Run();
+            });
+
+            StringAssert.Contains("Isolation level `Snapshot` is unsupport by the transport. Consider not sharing the transaction between transport and persistence if persistence should use `IsolationLevel.Snapshot` by using `TransportTransactionMode.SendsAtomicWithReceive` or lower.", ex.Message);
+        }
         public class Context : ScenarioContext
         {
             public bool Done { get; set; }
@@ -34,9 +71,9 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    c.UseTransport<MsmqTransport>()
-                        .Transactions(TransportTransactionMode.TransactionScope)
-                        .TransactionScopeOptions(isolationLevel: IsolationLevel.RepeatableRead);
+                    c.UseTransport<MsmqTransport>();
+                    //.Transactions(TransportTransactionMode.TransactionScope)
+                    //.TransactionScopeOptions(isolationLevel: isolationLevel);
                 });
             }
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
@@ -33,7 +33,7 @@
                     .Run();
 
             Assert.True(context.AmbientTransactionPresent, "There should be a ambient transaction present");
-            Assert.AreEqual(context.IsolationLevel, isolationLevel, "There should be a ambient transaction present");
+            Assert.AreEqual(context.IsolationLevel, isolationLevel, "There should be an ambient transaction present");
         }
 
         [Test]

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
@@ -41,7 +41,7 @@
         {
             var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
             {
-                var context = await Scenario.Define<Context>()
+                await Scenario.Define<Context>()
                         .WithEndpoint<ScopeEndpoint>(g =>
                         {
                             g.CustomConfig(c =>
@@ -77,6 +77,7 @@
 
             class MyMessageHandler : IHandleMessages<MyMessage>
             {
+                // ReSharper disable once UnusedAutoPropertyAccessor.Local
                 public Context Context { get; set; }
 
                 public Task Handle(MyMessage message, IMessageHandlerContext context)

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
@@ -56,7 +56,7 @@
                         .Run();
             });
 
-            StringAssert.Contains("Isolation level `Snapshot` is unsupport by the transport. Consider not sharing the transaction between transport and persistence if persistence should use `IsolationLevel.Snapshot` by using `TransportTransactionMode.SendsAtomicWithReceive` or lower.", ex.Message);
+            StringAssert.Contains("Isolation level `Snapshot` is not supported by the transport. Consider not sharing the transaction between transport and persistence if persistence should use `IsolationLevel.Snapshot` by using `TransportTransactionMode.SendsAtomicWithReceive` or lower.", ex.Message);
         }
         public class Context : ScenarioContext
         {

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
@@ -71,9 +71,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    c.UseTransport<MsmqTransport>();
-                    //.Transactions(TransportTransactionMode.TransactionScope)
-                    //.TransactionScopeOptions(isolationLevel: isolationLevel);
+                    c.UseTransport<MsmqTransport>(); // Required, to prevent runtime failure.
                 });
             }
 

--- a/src/NServiceBus.Transport.Msmq.sln.DotSettings
+++ b/src/NServiceBus.Transport.Msmq.sln.DotSettings
@@ -591,6 +591,9 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>

--- a/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
@@ -46,7 +46,7 @@ namespace NServiceBus
 
             if (isolationLevel.HasValue && isolationLevel.Value == IsolationLevel.Snapshot)
             {
-                throw new ArgumentException("Isolation level `Snapshot` is unsupport by the transport. Consider not sharing the transaction between transport and persistence if persistence should use `IsolationLevel.Snapshot` by using `TransportTransactionMode.SendsAtomicWithReceive` or lower.", nameof(isolationLevel));
+                throw new ArgumentException("Isolation level `Snapshot` is not supported by the transport. Consider not sharing the transaction between transport and persistence if persistence should use `IsolationLevel.Snapshot` by using `TransportTransactionMode.SendsAtomicWithReceive` or lower.", nameof(isolationLevel));
             }
 
             transportExtensions.GetSettings().Set<MsmqScopeOptions>(new MsmqScopeOptions(timeout, isolationLevel));

--- a/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
@@ -43,10 +43,16 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
             Guard.AgainstNegativeAndZero(nameof(timeout), timeout);
+
+            if (isolationLevel.HasValue && isolationLevel.Value == IsolationLevel.Snapshot)
+            {
+                throw new ArgumentException("Isolation level `Snapshot` is unsupport by the transport. Consider not sharing the transaction between transport and persistence if persistence should use `IsolationLevel.Snapshot` by using `TransportTransactionMode.SendsAtomicWithReceive` or lower.", nameof(isolationLevel));
+            }
+
             transportExtensions.GetSettings().Set<MsmqScopeOptions>(new MsmqScopeOptions(timeout, isolationLevel));
             return transportExtensions;
         }
-        
+
         /// <summary>
         /// Sets a distribution strategy for a given endpoint.
         /// </summary>
@@ -76,7 +82,7 @@ namespace NServiceBus
             Guard.AgainstNull(nameof(config), config);
             config.GetSettings().Set("UseDeadLetterQueueForMessagesWithTimeToBeReceived", true);
         }
-       
+
         /// <summary>
         /// Disables the automatic queue creation when installers are enabled using `EndpointConfiguration.EnableInstallers()`.
         /// </summary>
@@ -116,7 +122,7 @@ namespace NServiceBus
             Guard.AgainstNull(nameof(config), config);
             config.GetSettings().Set("UseConnectionCache", false);
         }
-        
+
         /// <summary>
         /// This setting should be used with caution. As the queues are not transactional, any message that has
         /// an exception during processing will not be rolled back to the queue. Therefore this setting must only
@@ -140,7 +146,7 @@ namespace NServiceBus
             Guard.AgainstNull(nameof(config), config);
             config.GetSettings().Set("UseJournalQueue", true);
         }
-        
+
         /// <summary>
         /// Overrides the TTRQ timespan. The default value if not set is Message.InfiniteTimeout
         /// </summary>
@@ -151,6 +157,6 @@ namespace NServiceBus
             Guard.AgainstNull(nameof(config), config);
             Guard.AgainstNegativeAndZero(nameof(timeToReachQueue), timeToReachQueue);
             config.GetSettings().Set("TimeToReachQueue", timeToReachQueue);
-        }       
+        }
     }
 }


### PR DESCRIPTION
Fixes #132