### PR TITLE
Disable Native TTBR in Transactions

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -17,7 +17,7 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
         var transportConfig = configuration.UseTransport<MsmqTransport>();
         transportConfig.DisableConnectionCachingForSends();
         configuration.GetSettings().Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
-        configuration.GetSettings().SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", true);
+        configuration.GetSettings().SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", false);
 
         var routingConfig = transportConfig.Routing();
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -17,6 +17,7 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
         var transportConfig = configuration.UseTransport<MsmqTransport>();
         transportConfig.DisableConnectionCachingForSends();
         configuration.GetSettings().Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
+        configuration.GetSettings().SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", true);
 
         var routingConfig = transportConfig.Routing();
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -17,7 +17,7 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
         var transportConfig = configuration.UseTransport<MsmqTransport>();
         transportConfig.DisableConnectionCachingForSends();
         configuration.GetSettings().Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
-        configuration.GetSettings().SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", false);
+        transportConfig.IgnoreIncomingTimeToBeReceivedHeaders();
 
         var routingConfig = transportConfig.Routing();
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
@@ -4,6 +4,7 @@
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
     using NUnit.Framework;
     using System;
     using System.Threading.Tasks;
@@ -15,6 +16,7 @@
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<SomeEndpoint>(endpoint => endpoint
+                    .CustomConfig(c => c.GetSettings().Set("IgnoreIncomingTimeToBeReceivedHeaders", false))
                     .When(async (session, ctx) =>
                     {
                         var sendOptions = new SendOptions();

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
@@ -7,7 +7,7 @@
     using NUnit.Framework;
     using System;
     using System.Threading.Tasks;
-    using NServiceBus.Configuration.AdvancedExtensibility;
+    using Configuration.AdvancedExtensibility;
 
     class When_message_with_expired_ttbr_header_is_received : NServiceBusAcceptanceTest
     {

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
@@ -41,7 +41,7 @@
 
             public class SomeMessageHandler : IHandleMessages<SomeMessage>
             {
-                private Context scenarioContext;
+                Context scenarioContext;
 
                 public SomeMessageHandler(Context scenarioContext)
                 {

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.TimeToBeReceived
 {
     using NServiceBus;
-    using NServiceBus.AcceptanceTesting;
+    using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.TimeToBeReceived
+{
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using System;
+    using System.Threading.Tasks;
+
+    class When_message_with_expired_ttbr_header_is_received : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Message_should_not_be_processed()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SomeEndpoint>(endpoint => endpoint
+                    .When(async (session, ctx) =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.RouteToThisEndpoint();
+                        sendOptions.SetHeader(Headers.TimeSent, DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow.AddSeconds(-10)));
+                        sendOptions.SetHeader(Headers.TimeToBeReceived, TimeSpan.FromSeconds(5).ToString());
+
+                        await session.Send(new SomeMessage(), sendOptions);
+                        ctx.WasSent = true;
+                    })
+                )
+                .Run(TimeSpan.FromSeconds(5));
+
+            Assert.IsTrue(context.WasSent, "Message was sent");
+            Assert.IsFalse(context.WasReceived, "Message was processed");
+        }
+
+        class SomeEndpoint : EndpointConfigurationBuilder
+        {
+            public SomeEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class SomeMessageHandler : IHandleMessages<SomeMessage>
+            {
+                private Context scenarioContext;
+
+                public SomeMessageHandler(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    scenarioContext.WasReceived = true;
+                    return TaskEx.CompletedTask;
+                }
+            }
+        }
+
+        class SomeMessage : IMessage
+        {
+
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool WasSent { get; set; }
+            public bool WasReceived { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
@@ -4,7 +4,7 @@
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.Configuration.AdvancedExtensibility;
+    using Configuration.AdvancedExtensibility;
     using NUnit.Framework;
     using System;
     using System.Threading.Tasks;

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_message_with_expired_ttbr_header_is_received.cs
@@ -7,6 +7,7 @@
     using NUnit.Framework;
     using System;
     using System.Threading.Tasks;
+    using NServiceBus.Configuration.AdvancedExtensibility;
 
     class When_message_with_expired_ttbr_header_is_received : NServiceBusAcceptanceTest
     {
@@ -36,7 +37,10 @@
         {
             public SomeEndpoint()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(config => 
+                    // NOTE: This is resetting the default
+                    config.GetSettings().Set("IgnoreIncomingTimeToBeReceivedHeaders", false)
+                );
             }
 
             public class SomeMessageHandler : IHandleMessages<SomeMessage>

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_sending_message_with_ttbr.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_sending_message_with_ttbr.cs
@@ -1,0 +1,102 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.TimeToBeReceived
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using System;
+    using System.Messaging;
+    using System.Threading.Tasks;
+    using System.Transactions;
+
+    class When_sending_message_with_ttbr : NServiceBusAcceptanceTest
+    {
+        string QueuePath(string endpointName) => $".\\private$\\{endpointName}";
+
+
+        [Test]
+        public async Task Uses_native_ttbr_outside_of_transaction()
+        {
+            var spyQueueName = "NativeTtbrSpyQueue";
+            var queuePath = QueuePath(spyQueueName);
+            RecreateQueue(queuePath);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(endpoint => endpoint
+                    .When(async (session, ctx) =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.SetDestination(spyQueueName);
+                        await session.Send(new SomeMessage(), sendOptions);
+                        ctx.MessageSent = true;
+                    })
+                )
+                .Done(ctx => ctx.MessageSent)
+                .Run();
+
+            using(var queue = new MessageQueue(queuePath))
+            {
+                queue.MessageReadPropertyFilter.TimeToBeReceived = true;
+                var message = queue.Receive();
+                Assert.AreEqual(TimeSpan.Parse("00:00:30"), message.TimeToBeReceived, "Native TTBR should be set");
+            }
+        }
+
+        [Test]
+        public async Task Throws_if_native_ttbr_enabled_inside_transaction()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(endpoint => endpoint
+                    .When(async (session, ctx) =>
+                    {
+                        using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+                        {
+                            try
+                            {
+                                await session.SendLocal(new SomeMessage());
+                            }
+                            catch (Exception ex)
+                            {
+                                ctx.ThrownException = ex;
+                            }
+                        }
+                    })
+                )
+                .Done(ctx => ctx.ThrownException != null)
+                .Run();
+
+            StringAssert.Contains("Sending messages with a custom TimeToBeReceived is not supported on transactional MSMQ", context.ThrownException.Message);
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        [TimeToBeReceived("00:00:30")]
+        class SomeMessage : IMessage
+        {
+
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageSent { get; set; }
+
+            public Exception ThrownException { get; set; }
+        }
+
+        static void RecreateQueue(string queuePath)
+        {
+            if (MessageQueue.Exists(queuePath))
+            {
+                MessageQueue.Delete(queuePath);
+            }
+
+            MessageQueue.Create(queuePath, true);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_sending_message_with_ttbr.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_sending_message_with_ttbr.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.TimeToBeReceived
 {
-    using NServiceBus.AcceptanceTesting;
+    using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_sending_message_with_ttbr.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TimeToBeReceived/When_sending_message_with_ttbr.cs
@@ -34,6 +34,8 @@
                 .Done(ctx => ctx.MessageSent)
                 .Run();
 
+            Assert.IsTrue(context.MessageSent, "Message was sent");
+
             using(var queue = new MessageQueue(queuePath))
             {
                 queue.MessageReadPropertyFilter.TimeToBeReceived = true;
@@ -49,7 +51,7 @@
                 .WithEndpoint<Sender>(endpoint => endpoint
                     .When(async (session, ctx) =>
                     {
-                        using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+                        using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                         {
                             try
                             {
@@ -76,7 +78,7 @@
                     .CustomConfig(endpointConfiguration => endpointConfiguration.UseTransport<MsmqTransport>().DisableNativeTimeToBeReceivedInTransactions())
                     .When(async (session, ctx) =>
                     {
-                        using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+                        using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                         {
                             await session.SendLocal(new SomeMessage());
                             ctx.MessageSent = true;

--- a/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -28,6 +28,7 @@ namespace NServiceBus
         public static void DisableConnectionCachingForSends(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static void DisableDeadLetterQueueing(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static void DisableInstaller(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
+        public static void DisableNativeTimeToBeReceivedInTransactions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static void EnableJournaling(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static NServiceBus.InstanceMappingFileSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
         public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }

--- a/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -30,6 +30,7 @@ namespace NServiceBus
         public static void DisableInstaller(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static void DisableNativeTimeToBeReceivedInTransactions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static void EnableJournaling(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
+        public static void IgnoreIncomingTimeToBeReceivedHeaders(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static NServiceBus.InstanceMappingFileSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
         public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
         public static void TimeToReachQueue(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, System.TimeSpan timeToReachQueue) { }

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqMessagePumpTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqMessagePumpTests.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Transport.Msmq.Tests
         [Test]
         public void ShouldThrowIfConfiguredToReceiveFromRemoteQueue()
         {
-            var messagePump = new MessagePump(mode => null, TimeSpan.Zero);
+            var messagePump = new MessagePump(mode => null, TimeSpan.Zero, false);
             var pushSettings = new PushSettings("queue@remote", "error", false, TransportTransactionMode.None);
 
             var exception = Assert.Throws<Exception>(() =>

--- a/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
@@ -15,7 +15,7 @@ class ConfigureMsmqTransportInfrastructure : IConfigureTransportInfrastructure
         var msmqTransportDefinition = new MsmqTransport();
         settingsHolder = settings;
         settingsHolder.Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
-        settingsHolder.SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", false);
+        settingsHolder.SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", true); // Acual default is False
         return new TransportConfigurationResult
         {
             TransportInfrastructure = msmqTransportDefinition.Initialize(settingsHolder, null),

--- a/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
@@ -15,6 +15,7 @@ class ConfigureMsmqTransportInfrastructure : IConfigureTransportInfrastructure
         var msmqTransportDefinition = new MsmqTransport();
         settingsHolder = settings;
         settingsHolder.Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
+        settingsHolder.SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", true);
         return new TransportConfigurationResult
         {
             TransportInfrastructure = msmqTransportDefinition.Initialize(settingsHolder, null),

--- a/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
@@ -15,7 +15,7 @@ class ConfigureMsmqTransportInfrastructure : IConfigureTransportInfrastructure
         var msmqTransportDefinition = new MsmqTransport();
         settingsHolder = settings;
         settingsHolder.Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
-        settingsHolder.SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", true);
+        settingsHolder.SetDefault("IgnoreIncomingTimeToBeReceivedHeaders", false);
         return new TransportConfigurationResult
         {
             TransportInfrastructure = msmqTransportDefinition.Initialize(settingsHolder, null),

--- a/src/NServiceBus.Transport.Msmq/MessagePump.cs
+++ b/src/NServiceBus.Transport.Msmq/MessagePump.cs
@@ -13,10 +13,11 @@ namespace NServiceBus.Transport.Msmq
 
     class MessagePump : IPushMessages, IDisposable
     {
-        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory, TimeSpan messageEnumeratorTimeout)
+        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory, TimeSpan messageEnumeratorTimeout, bool discardExpiredTtbrMessages)
         {
             this.receiveStrategyFactory = receiveStrategyFactory;
             this.messageEnumeratorTimeout = messageEnumeratorTimeout;
+            this.discardExpiredTtbrMessages = discardExpiredTtbrMessages;
         }
 
         public void Dispose()
@@ -54,7 +55,7 @@ namespace NServiceBus.Transport.Msmq
 
             receiveStrategy = receiveStrategyFactory(settings.RequiredTransactionMode);
 
-            receiveStrategy.Init(inputQueue, errorQueue, onMessage, onError, criticalError);
+            receiveStrategy.Init(inputQueue, errorQueue, onMessage, onError, criticalError, discardExpiredTtbrMessages);
 
             return TaskEx.CompletedTask;
         }
@@ -237,6 +238,7 @@ namespace NServiceBus.Transport.Msmq
         Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory;
         TimeSpan messageEnumeratorTimeout;
         ConcurrentDictionary<Task, Task> runningReceiveTasks;
+        bool discardExpiredTtbrMessages;
 
         static ILog Logger = LogManager.GetLogger<MessagePump>();
 

--- a/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
@@ -39,6 +39,9 @@ namespace NServiceBus
         /// If not specified the default transaction timeout of the machine will be used and the isolation level will be set to
         /// <see cref="IsolationLevel.ReadCommitted"/>.
         /// </remarks>
+        /// <param name="transportExtensions">MSMQ Transport configuration object.</param>
+        /// <param name="timeout">Transaction timeout duration.</param>
+        /// <param name="isolationLevel">Transaction isolation level.</param>
         public static TransportExtensions<MsmqTransport> TransactionScopeOptions(this TransportExtensions<MsmqTransport> transportExtensions, TimeSpan? timeout = null, IsolationLevel? isolationLevel = null)
         {
             Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
@@ -56,7 +59,7 @@ namespace NServiceBus
         /// <summary>
         /// Sets a distribution strategy for a given endpoint.
         /// </summary>
-        /// <param name="config">Config object.</param>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         /// <param name="distributionStrategy">The instance of a distribution strategy.</param>
         public static void SetMessageDistributionStrategy(this RoutingSettings<MsmqTransport> config, DistributionStrategy distributionStrategy)
         {
@@ -68,6 +71,7 @@ namespace NServiceBus
         /// <summary>
         /// Returns the configuration options for the file based instance mapping file.
         /// </summary>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static InstanceMappingFileSettings InstanceMappingFile(this RoutingSettings<MsmqTransport> config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -77,6 +81,7 @@ namespace NServiceBus
         /// <summary>
         /// Moves messages that have exceeded their TimeToBeReceived to the dead letter queue instead of discarding them.
         /// </summary>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static void UseDeadLetterQueueForMessagesWithTimeToBeReceived(this TransportExtensions<MsmqTransport> config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -92,6 +97,7 @@ namespace NServiceBus
         /// The installers might still need to be enabled to fulfill the installation needs of other components, but this method allows
         /// scripts to be used for queue creation instead.
         /// </remarks>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static void DisableInstaller(this TransportExtensions<MsmqTransport> config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -103,7 +109,7 @@ namespace NServiceBus
         /// in the dead letter queue. Therefore this setting must only be used where loss of messages 
         /// is an acceptable scenario. 
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static void DisableDeadLetterQueueing(this TransportExtensions<MsmqTransport> config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -116,7 +122,7 @@ namespace NServiceBus
         /// Turning connection caching off will negatively impact the message throughput in 
         /// most scenarios.
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static void DisableConnectionCachingForSends(this TransportExtensions<MsmqTransport> config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -128,7 +134,7 @@ namespace NServiceBus
         /// an exception during processing will not be rolled back to the queue. Therefore this setting must only
         /// be used where loss of messages is an acceptable scenario.  
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static void UseNonTransactionalQueues(this TransportExtensions<MsmqTransport> config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -140,7 +146,7 @@ namespace NServiceBus
         /// Should be used ONLY when debugging as it can 
         /// potentially use up the MSMQ journal storage quota based on the message volume.
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static void EnableJournaling(this TransportExtensions<MsmqTransport> config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -148,10 +154,10 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Overrides the TTRQ timespan. The default value if not set is Message.InfiniteTimeout
+        /// Overrides the Time-To-Reach-Queue (TTRQ) timespan. The default value if not set is Message.InfiniteTimeout
         /// </summary>
-        /// <param name="config"></param>
-        /// <param name="timeToReachQueue">Timespan for the TTRQ</param>
+        /// <param name="config">MSMQ Transport configuration object.</param>
+        /// <param name="timeToReachQueue">Timespan for the Time-To-Reach-Queue (TTRQ)</param>
         public static void TimeToReachQueue(this TransportExtensions<MsmqTransport> config, TimeSpan timeToReachQueue)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -160,12 +166,23 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Disables native TTBR when combined with transactions.
+        /// Disables native Time-To-Be-Received (TTBR) when combined with transactions.
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="config">MSMQ Transport configuration object.</param>
         public static void DisableNativeTimeToBeReceivedInTransactions(this TransportExtensions<MsmqTransport> config)
         {
+            Guard.AgainstNull(nameof(config), config);
             config.GetSettings().Set("DisableNativeTtbrInTransactions", true);
+        }
+        
+        /// <summary>
+        /// Ignore incoming Time-To-Be-Received (TTBR) headers. By default an expired TTBR header will result in the message to be discarded.
+        /// </summary>
+        /// <param name="config">MSMQ Transport configuration object.</param>
+        public static void IgnoreIncomingTimeToBeReceivedHeaders(this TransportExtensions<MsmqTransport> config)
+        {
+            Guard.AgainstNull(nameof(config), config);
+            config.GetSettings().Set("IgnoreIncomingTimeToBeReceivedHeaders", true);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
@@ -158,5 +158,14 @@ namespace NServiceBus
             Guard.AgainstNegativeAndZero(nameof(timeToReachQueue), timeToReachQueue);
             config.GetSettings().Set("TimeToReachQueue", timeToReachQueue);
         }
+
+        /// <summary>
+        /// Disables native TTBR when combined with transactions.
+        /// </summary>
+        /// <param name="config"></param>
+        public static void DisableNativeTimeToBeReceivedInTransactions(this TransportExtensions<MsmqTransport> config)
+        {
+            config.GetSettings().Set("DisableNativeTtbrInTransactions", true);
+        }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
@@ -75,6 +75,11 @@ namespace NServiceBus.Transport.Msmq
             {
                 LabelGenerator = generator;
             }
+
+            if(settings.TryGet<bool>("DisableNativeTtbrInTransactions", out var disableNativeTtbrInTransactions))
+            {
+                DisableNativeTtbrInTransactions = disableNativeTtbrInTransactions;
+            }
         }
 
         public bool UseDeadLetterQueue { get; set; }
@@ -96,5 +101,7 @@ namespace NServiceBus.Transport.Msmq
         public Func<IReadOnlyDictionary<string, string>, string> LabelGenerator { get; set; }
 
         public TimeSpan MessageEnumeratorTimeout { get; set; }
+
+        public bool DisableNativeTtbrInTransactions { get; set; }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
@@ -80,6 +80,8 @@ namespace NServiceBus.Transport.Msmq
             {
                 DisableNativeTtbrInTransactions = disableNativeTtbrInTransactions;
             }
+
+            IgnoreIncomingTimeToBeReceivedHeaders = settings.GetOrDefault<bool>("IgnoreIncomingTimeToBeReceivedHeaders");
         }
 
         public bool UseDeadLetterQueue { get; set; }
@@ -103,5 +105,7 @@ namespace NServiceBus.Transport.Msmq
         public TimeSpan MessageEnumeratorTimeout { get; set; }
 
         public bool DisableNativeTtbrInTransactions { get; set; }
+
+        public bool IgnoreIncomingTimeToBeReceivedHeaders { get; set; }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
@@ -90,7 +90,7 @@ namespace NServiceBus.Transport.Msmq
             }
 
             return new TransportReceiveInfrastructure(
-                () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, msmqSettings.ScopeOptions.TransactionOptions), msmqSettings.MessageEnumeratorTimeout),
+                () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, msmqSettings.ScopeOptions.TransactionOptions), msmqSettings.MessageEnumeratorTimeout, !msmqSettings.IgnoreIncomingTimeToBeReceivedHeaders),
                 () =>
                 {
                     if (msmqSettings.ExecuteInstaller)

--- a/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
@@ -101,6 +101,12 @@ namespace NServiceBus.Transport.Msmq
 
         protected async Task<bool> TryProcessMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction)
         {
+            if (TimeToBeReceived.HasElapsed(headers))
+            {
+                Logger.Debug($"Discarding message {messageId} due to lapsed Time To Be Received header");
+                return false;
+            }
+
             using (var tokenSource = new CancellationTokenSource())
             {
                 var body = await ReadStream(bodyStream).ConfigureAwait(false);

--- a/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
@@ -14,13 +14,14 @@ namespace NServiceBus.Transport.Msmq
     {
         public abstract Task ReceiveMessage();
 
-        public void Init(MessageQueue inputQueue, MessageQueue errorQueue, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, CriticalError criticalError)
+        public void Init(MessageQueue inputQueue, MessageQueue errorQueue, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, CriticalError criticalError, bool discardExpiredTtbrMessages)
         {
             this.inputQueue = inputQueue;
             this.errorQueue = errorQueue;
             this.onMessage = onMessage;
             this.onError = onError;
             this.criticalError = criticalError;
+            this.discardExpiredTtbrMessages = discardExpiredTtbrMessages;
         }
 
         protected bool TryReceive(MessageQueueTransactionType transactionType, out Message message)
@@ -101,7 +102,7 @@ namespace NServiceBus.Transport.Msmq
 
         protected async Task<bool> TryProcessMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction)
         {
-            if (TimeToBeReceived.HasElapsed(headers))
+            if (discardExpiredTtbrMessages && TimeToBeReceived.HasElapsed(headers))
             {
                 Logger.Debug($"Discarding message {messageId} due to lapsed Time To Be Received header");
                 return false;
@@ -154,6 +155,7 @@ namespace NServiceBus.Transport.Msmq
         Func<MessageContext, Task> onMessage;
         Func<ErrorContext, Task<ErrorHandleResult>> onError;
         CriticalError criticalError;
+        bool discardExpiredTtbrMessages;
 
         static ILog Logger = LogManager.GetLogger<ReceiveStrategy>();
     }

--- a/src/NServiceBus.Transport.Msmq/TimeToBeReceived.cs
+++ b/src/NServiceBus.Transport.Msmq/TimeToBeReceived.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus.Transport.Msmq
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal static class TimeToBeReceived
+    {
+        public static bool HasElapsed(Dictionary<string, string> headers)
+        {
+            if(!TryGetTtbr(headers, out var ttbr))
+            {
+                return false;
+            }
+
+            if(!TryGetTimeSent(headers, out var timeSent))
+            {
+                return false;
+            }
+
+            var cutOff = timeSent + ttbr;
+            var receiveTime = DateTime.UtcNow;
+
+            return cutOff < receiveTime;            
+        }
+
+        static bool TryGetTtbr(Dictionary<string, string> headers, out TimeSpan ttbr)
+        {
+            ttbr = TimeSpan.Zero;
+            return headers.TryGetValue(Headers.TimeToBeReceived, out var ttbrString)
+                && TimeSpan.TryParse(ttbrString, out ttbr);
+        }
+
+        static bool TryGetTimeSent(Dictionary<string, string> headers, out DateTime timeSent)
+        {
+            if (headers.TryGetValue(Headers.TimeSent, out var timeSentString))
+            {
+                timeSent = DateTimeExtensions.ToUtcDateTime(timeSentString);
+                return true;
+            }
+
+            timeSent = DateTime.MinValue;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1 

When combining a message with TTBR and transactions, currently you get an exception. This PR creates a setting that causes the system to fall back on "soft" TTBR when this happens.

- Discards messages with an expired TTBR header when received by an endpoint (Soft TTBR)
  - This behavior can be turned off with an API: `endpointConfiguration.IgnoreIncomingTimeToBeReceivedHeaders();`
- Adds configuration switch: `endpointConfiguration.DisableNativeTimeToBeReceivedInTransactions();`
  - If set, then messages sent in a transaction skip native TTBR (and fall back on soft TTBR)
  - If not set, then messages sent in a transaction with TTBR throw an exception.