### PR TITLE
Simplify the pump stop to no longer use the task tracking approach

### DIFF
--- a/src/NServiceBus.Transport.Msmq/MessagePump.cs
+++ b/src/NServiceBus.Transport.Msmq/MessagePump.cs
@@ -1,9 +1,7 @@
 namespace NServiceBus.Transport.Msmq
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Diagnostics;
-    using System.Linq;
     using System.Messaging;
     using System.Threading;
     using System.Threading.Tasks;
@@ -64,8 +62,8 @@ namespace NServiceBus.Transport.Msmq
         {
             MessageQueue.ClearConnectionCache();
 
-            runningReceiveTasks = new ConcurrentDictionary<Task, Task>();
-            concurrencyLimiter = new SemaphoreSlim(limitations.MaxConcurrency);
+            maxConcurrency = limitations.MaxConcurrency;
+            concurrencyLimiter = new SemaphoreSlim(limitations.MaxConcurrency, limitations.MaxConcurrency);
             cancellationTokenSource = new CancellationTokenSource();
 
             cancellationToken = cancellationTokenSource.Token;
@@ -78,21 +76,24 @@ namespace NServiceBus.Transport.Msmq
         {
             cancellationTokenSource.Cancel();
 
-            // ReSharper disable once MethodSupportsCancellation
-            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30));
-            var allTasks = runningReceiveTasks.Values.Concat(new[]
-            {
-                messagePumpTask
-            });
-            var finishedTask = await Task.WhenAny(Task.WhenAll(allTasks), timeoutTask).ConfigureAwait(false);
+            await messagePumpTask.ConfigureAwait(false);
 
-            if (finishedTask.Equals(timeoutTask))
+            try
+            {
+                using (var shutdownCancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+                {
+                    while (concurrencyLimiter.CurrentCount != maxConcurrency)
+                    {
+                        await Task.Delay(50, shutdownCancellationTokenSource.Token).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
             {
                 Logger.Error("The message pump failed to stop with in the time allowed(30s)");
             }
 
             concurrencyLimiter.Dispose();
-            runningReceiveTasks.Clear();
             inputQueue.Dispose();
             errorQueue.Dispose();
         }
@@ -148,24 +149,7 @@ namespace NServiceBus.Transport.Msmq
 
                     await concurrencyLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-                    var receiveTask = ReceiveMessage();
-
-                    runningReceiveTasks.TryAdd(receiveTask, receiveTask);
-
-                    // We insert the original task into the runningReceiveTasks because we want to await the completion
-                    // of the running receives. ExecuteSynchronously is a request to execute the continuation as part of
-                    // the transition of the antecedents completion phase. This means in most of the cases the continuation
-                    // will be executed during this transition and the antecedent task goes into the completion state only
-                    // after the continuation is executed. This is not always the case. When the TPL thread handling the
-                    // antecedent task is aborted the continuation will be scheduled. But in this case we don't need to await
-                    // the continuation to complete because only really care about the receive operations. The final operation
-                    // when shutting down is a clear of the running tasks anyway.
-                    receiveTask.ContinueWith((t, state) =>
-                    {
-                        var receiveTasks = (ConcurrentDictionary<Task, Task>) state;
-                        receiveTasks.TryRemove(t, out _);
-                    }, runningReceiveTasks, TaskContinuationOptions.ExecuteSynchronously)
-                        .Ignore();
+                    ReceiveMessage().Ignore();
                 }
             }
         }
@@ -225,6 +209,7 @@ namespace NServiceBus.Transport.Msmq
 
         CancellationToken cancellationToken;
         CancellationTokenSource cancellationTokenSource;
+        int maxConcurrency;
         SemaphoreSlim concurrencyLimiter;
         MessageQueue errorQueue;
         MessageQueue inputQueue;
@@ -237,7 +222,6 @@ namespace NServiceBus.Transport.Msmq
         RepeatedFailuresOverTimeCircuitBreaker receiveCircuitBreaker;
         Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory;
         TimeSpan messageEnumeratorTimeout;
-        ConcurrentDictionary<Task, Task> runningReceiveTasks;
         bool discardExpiredTtbrMessages;
 
         static ILog Logger = LogManager.GetLogger<MessagePump>();

--- a/src/NServiceBus.Transport.Msmq/MessagePump.cs
+++ b/src/NServiceBus.Transport.Msmq/MessagePump.cs
@@ -149,7 +149,7 @@ namespace NServiceBus.Transport.Msmq
 
                     await concurrencyLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-                    ReceiveMessage().Ignore();
+                    _ = ReceiveMessage();
                 }
             }
         }

--- a/src/NServiceBus.Transport.Msmq/Utils/TaskEx.cs
+++ b/src/NServiceBus.Transport.Msmq/Utils/TaskEx.cs
@@ -8,13 +8,6 @@ namespace NServiceBus.Transport.Msmq
     {
         const string TaskIsNullExceptionMessage = "Return a Task or mark the method as async.";
 
-        // ReSharper disable once UnusedParameter.Global
-        // Used to explicitly suppress the compiler warning about
-        // using the returned value from async operations
-        public static void Ignore(this Task task)
-        {
-        }
-
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask
         public static readonly Task CompletedTask = Task.FromResult(0);
 


### PR DESCRIPTION
Alternative #149 would also remove the timeout of 30 seconds

The task tracking approach is something we mostly moved away from because it is complex to understand and not as bullet proof as async idling over the semaphore.