### PR TITLE
Subscription storage is deduplicated immediate after write

### DIFF
--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
@@ -24,7 +24,7 @@
             await storage.Subscribe(new Subscriber("sub2", "endpointA"), messageType, new ContextBag());
 
             var storedMessages = queue.GetAllMessages().ToArray();
-            Assert.That(storedMessages.Length, Is.EqualTo(2), "");
+            Assert.That(storedMessages.Length, Is.EqualTo(2));
 
             storage = CreateAndInit(queue);
             var subscribers = (await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag())).ToArray();

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
@@ -312,7 +312,7 @@
                 return Messages.ToArray();
             }
 
-            public string Send(string body, string label)
+            public void Send(string body, string label)
             {
                 var id = Guid.NewGuid().ToString();
 
@@ -323,8 +323,6 @@
                     Label = label,
                     Id = id
                 });
-
-                return id;
             }
 
             public void TryReceiveById(string messageId)

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
@@ -167,9 +167,10 @@
 
             var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
 
+            Assert.AreEqual(1, subscribers.Count(), "Subscribers count");
             var subscriber = subscribers.Single();
-            Assert.AreEqual("sub1", subscriber.TransportAddress);
-            Assert.AreEqual("endpoint", subscriber.Endpoint);
+            Assert.AreEqual("sub1", subscriber.TransportAddress, "subscriber.TransportAddress");
+            Assert.AreEqual("endpoint", subscriber.Endpoint, "subscriber.Endpoint");
         }
 
         [Test]

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/IMsmqSubscriptionStorageQueue.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/IMsmqSubscriptionStorageQueue.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Persistence.Msmq
     interface IMsmqSubscriptionStorageQueue
     {
         IEnumerable<MsmqSubscriptionMessage> GetAllMessages();
-        string Send(string body, string label);
+        void Send(string body, string label);
         void TryReceiveById(string messageId);
     }
 }

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorageQueue.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorageQueue.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.Persistence.Msmq
             return queue.GetAllMessages().Select(m => new MsmqSubscriptionMessage(m));
         }
 
-        public string Send(string body, string label)
+        public void Send(string body, string label)
         {
             var toSend = new Message
             {
@@ -44,8 +44,6 @@ namespace NServiceBus.Persistence.Msmq
             };
 
             queue.Send(toSend, transactionTypeToUseForSend);
-
-            return toSend.Id;
         }
 
         public void TryReceiveById(string messageId)


### PR DESCRIPTION
Fixes #30

Previously subscription storage was deduplicated only at initialization which was confusing for users as they didn't expect duplicate entries. Now in-memory subscription state is not modified anymore after building. For (un)subscribes the storage will be updated and then the subscription state is rebuild from storage. This keeps the storage in sync and storage will always be leading.