### PR TITLE
Machine name remote check now checks  Ipv6 loopback and using DNS lookup

### DIFF
--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
@@ -43,13 +43,13 @@ namespace NServiceBus.Transport.Msmq.Tests
         [TestCase(".")]
         public void If_machine_is_looplocal_is_specified_is_remote_should_be_false(string machine)
         {
-            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + machine).IsRemote);
+            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + machine).IsRemote());
         }
 
         [Test]
         public void If_local_machine_name_is_remote_should_be_false()
         {
-            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + Environment.MachineName).IsRemote);
+            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + Environment.MachineName).IsRemote());
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace NServiceBus.Transport.Msmq.Tests
             {
                 Assert.Ignore($"Add `127.0.0.1 {machinename}` to hosts file for this test to run.");
             }
-            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + machinename).IsRemote);
+            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + machinename).IsRemote());
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
@@ -13,9 +13,9 @@ namespace NServiceBus.Transport.Msmq.Tests
         {
             var address = new MsmqAddress("replyToAddress", "replyToMachine");
             var returnAddress = address.MakeCompatibleWith(new MsmqAddress("someQueue", "destinationmachine"), _ =>
-             {
-                 throw new Exception("Should not call the lookup method");
-             });
+            {
+                throw new Exception("Should not call the lookup method");
+            });
             Assert.AreEqual("replyToMachine", returnAddress.Machine);
         }
 

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
@@ -1,9 +1,7 @@
 namespace NServiceBus.Transport.Msmq.Tests
 {
     using System;
-    using System.Linq;
     using System.Net;
-    using System.Runtime.InteropServices;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqAddressTests.cs
@@ -1,6 +1,9 @@
 namespace NServiceBus.Transport.Msmq.Tests
 {
     using System;
+    using System.Linq;
+    using System.Net;
+    using System.Runtime.InteropServices;
     using NUnit.Framework;
 
     [TestFixture]
@@ -11,10 +14,10 @@ namespace NServiceBus.Transport.Msmq.Tests
         public void If_both_addresses_are_specified_via_host_name_it_should_not_convert()
         {
             var address = new MsmqAddress("replyToAddress", "replyToMachine");
-            var returnAddress = address.MakeCompatibleWith(new MsmqAddress("someQueue","destinationmachine"), _ =>
-            {
-                throw new Exception("Should not call the lookup method");
-            });
+            var returnAddress = address.MakeCompatibleWith(new MsmqAddress("someQueue", "destinationmachine"), _ =>
+             {
+                 throw new Exception("Should not call the lookup method");
+             });
             Assert.AreEqual("replyToMachine", returnAddress.Machine);
         }
 
@@ -35,6 +38,35 @@ namespace NServiceBus.Transport.Msmq.Tests
             var address = new MsmqAddress("replyToAddress", "replyToMachine");
             var returnAddress = address.MakeCompatibleWith(new MsmqAddress("someQueue", "202.171.13.140"), _ => "10.10.10.10");
             Assert.AreEqual("10.10.10.10", returnAddress.Machine);
+        }
+
+        [Test]
+        [TestCase("::1")]
+        [TestCase(".")]
+        public void If_machine_is_looplocal_is_specified_is_remote_should_be_false(string machine)
+        {
+            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + machine).IsRemote);
+        }
+
+        [Test]
+        public void If_local_machine_name_is_remote_should_be_false()
+        {
+            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + Environment.MachineName).IsRemote);
+        }
+
+        [Test]
+        public void If_machine_name_is_local_ip_is_remote_should_be_false()
+        {
+            var machinename = "localtestmachinename";
+            try
+            {
+                Dns.GetHostAddresses(machinename);
+            }
+            catch
+            {
+                Assert.Ignore($"Add `127.0.0.1 {machinename}` to hosts file for this test to run.");
+            }
+            Assert.IsFalse(MsmqAddress.Parse("replyToAddress@" + machinename).IsRemote);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqAddress.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqAddress.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Transport.Msmq
 {
     using System;
+    using System.Linq;
     using System.Net;
     using Support;
 
@@ -48,14 +49,37 @@ namespace NServiceBus.Transport.Msmq
             return new MsmqAddress(queue, machineName);
         }
 
-        public bool IsRemote => Machine != RuntimeEnvironment.MachineName;
+        public bool IsRemote => Machine != RuntimeEnvironment.MachineName && IsLocalIpAddress(Machine) != true;
+
+        static bool? IsLocalIpAddress(string hostName)
+        {
+            if (string.IsNullOrWhiteSpace(hostName))
+            {
+                return null;
+            }
+            try
+            {
+                var hostIPs = Dns.GetHostAddresses(hostName);
+                var localIPs = Dns.GetHostAddresses(Dns.GetHostName());
+
+                if (hostIPs.Any(hostIp => IPAddress.IsLoopback(hostIp) || localIPs.Contains(hostIp)))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+            return false;
+        }
 
         static string ApplyLocalMachineConventions(string machineName)
         {
             if (
                 machineName == "." ||
                 machineName.ToLower() == "localhost" ||
-                machineName == IPAddress.Loopback.ToString()
+                IPAddress.TryParse(machineName, out var address) && IPAddress.IsLoopback(address)
                 )
             {
                 return RuntimeEnvironment.MachineName;

--- a/src/NServiceBus.Transport.Msmq/MsmqAddress.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqAddress.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.Transport.Msmq
             return new MsmqAddress(queue, machineName);
         }
 
-        public bool IsRemote => Machine != RuntimeEnvironment.MachineName && IsLocalIpAddress(Machine) != true;
+        public bool IsRemote() => Machine != RuntimeEnvironment.MachineName && IsLocalIpAddress(Machine) != true;
 
         static bool? IsLocalIpAddress(string hostName)
         {

--- a/src/NServiceBus.Transport.Msmq/MsmqQueueCreator.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqQueueCreator.cs
@@ -34,7 +34,7 @@ namespace NServiceBus.Transport.Msmq
 
             Logger.Debug($"Creating '{address}' if needed.");
 
-            if (msmqAddress.IsRemote)
+            if (msmqAddress.IsRemote())
             {
                 Logger.Info($"'{address}' is a remote queue and won't be created");
                 return;

--- a/src/NServiceBus.Transport.Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Transport.Msmq/QueuePermissions.cs
@@ -13,7 +13,7 @@
             var queuePath = msmqAddress.PathWithoutPrefix;
 
             Logger.Debug($"Checking if queue exists: {queuePath}.");
-            if (msmqAddress.IsRemote)
+            if (msmqAddress.IsRemote())
             {
                 Logger.Info($"Since {address} is remote, the queue could not be verified. Make sure the queue exists and that the address and permissions are correct. Messages could end up in the dead letter queue if configured incorrectly.");
                 return;


### PR DESCRIPTION
Fixes #133

The remote check not only checks the machine name but also checks if the address is an Ipv6 loopback address and uses DNS lookup to validate if the queues are remote.