### PR TITLE
Update to core alpha 842

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.840" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.842" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.840" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.107" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.840" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.842" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Transport.Msmq
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Threading.Tasks;
     using System.Transactions;
     using Transport;
@@ -60,7 +59,7 @@ namespace NServiceBus.Transport.Msmq
                 messagePumps.Add(pump.Id, pump);
             }
 
-            Receivers = new ReadOnlyDictionary<string, IMessageReceiver>(messagePumps);
+            Receivers = messagePumps;
         }
 
         public override Task Shutdown()

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.840" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />


### PR DESCRIPTION
So we no longer need to wrap the pump in a `ReadOnlyDictionary` as `Dictionary` already implements `IReadOnlyDictionary`.