### PR TITLE
Update to NServiceBus Core alpha 852

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.842" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.852" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TestableMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TestableMsmqTransport.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Transport;
@@ -11,11 +12,11 @@ class TestableMsmqTransport : MsmqTransport
 {
     public string[] ReceiveQueues = new string[0];
 
-    public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses)
+    public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
     {
         MessageEnumeratorTimeout = TimeSpan.FromMilliseconds(10);
         ReceiveQueues = receivers.Select(r => r.ReceiveAddress).ToArray();
 
-        return base.Initialize(hostSettings, receivers, sendingAddresses);
+        return base.Initialize(hostSettings, receivers, sendingAddresses, cancellationToken);
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -50,7 +51,7 @@
                     this.dispatcher = dispatcher;
                 }
 
-                protected override Task OnStart(IMessageSession session)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
                 {
                     // Simulating a v3.3 control message
                     var body = Encoding.UTF8.GetBytes(@"<?xml version=""1.0""?>
@@ -67,10 +68,10 @@
                     }, body);
 
                     var endpoint = Conventions.EndpointNamingConvention(typeof(TestingEndpoint));
-                    return dispatcher.Dispatch(new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(endpoint))), new TransportTransaction());
+                    return dispatcher.Dispatch(new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(endpoint))), new TransportTransaction(), cancellationToken);
                 }
 
-                protected override Task OnStop(IMessageSession session)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -85,7 +85,7 @@ namespace NServiceBus
         public bool UseTransactionalQueues { get; set; }
         public void ConfigureTransactionScope(System.TimeSpan? timeout = default, System.Transactions.IsolationLevel? isolationLevel = default) { }
         public override System.Collections.Generic.IReadOnlyCollection<NServiceBus.TransportTransactionMode> GetSupportedTransactionModes() { }
-        public override System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses) { }
+        public override System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken) { }
         public override string ToTransportAddress(NServiceBus.Transport.QueueAddress address) { }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqMessageDispatcherTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqMessageDispatcherTests.cs
@@ -4,6 +4,7 @@
     using System;
     using System.Collections.Generic;
     using System.Messaging;
+    using System.Threading;
     using NServiceBus.Performance.TimeToBeReceived;
     using Routing;
     using Transport;
@@ -84,7 +85,7 @@
                 dispatchProperties = dispatchProperties ?? new DispatchProperties();
                 var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(queueName), dispatchProperties);
 
-                await messageSender.Dispatch(new TransportOperations(transportOperation), new TransportTransaction());
+                await messageSender.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), CancellationToken.None);
 
                 using (var queue = new MessageQueue(path))
                 using (var message = queue.Receive(TimeSpan.FromSeconds(5)))

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqMessagePumpTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqMessagePumpTests.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Transport.Msmq.Tests
 {
     using System;
+    using System.Threading;
     using Transport;
     using NUnit.Framework;
 
@@ -12,11 +13,11 @@ namespace NServiceBus.Transport.Msmq.Tests
         public void ShouldThrowIfConfiguredToReceiveFromRemoteQueue()
         {
             var receiveSettings = new ReceiveSettings("test receiver", "queue@remote", false, false, "error");
-            var messagePump = new MessagePump(mode => null, TimeSpan.Zero, (_, __) => { }, new MsmqTransport(), receiveSettings);
+            var messagePump = new MessagePump(mode => null, TimeSpan.Zero, (_, __, ___) => { }, new MsmqTransport(), receiveSettings);
 
             var exception = Assert.ThrowsAsync<Exception>(async () =>
             {
-                await messagePump.Initialize(new PushRuntimeSettings(), context => null, context => null);
+                await messagePump.Initialize(new PushRuntimeSettings(), (context, ct) => null, (context, ct) => null, CancellationToken.None);
             });
 
             Assert.That(exception.Message, Does.Contain($"MSMQ Dequeuing can only run against the local machine. Invalid inputQueue name '{receiveSettings.ReceiveAddress}'."));

--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
-    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.98" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.152" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageIntegrationTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.Msmq.Tests.Persistence
 {
     using System.Messaging;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using NServiceBus.Persistence.Msmq;
@@ -10,24 +11,24 @@
 
     public class MsmqSubscriptionStorageIntegrationTests
     {
-        const string testQueueName = "NServiceBus.Core.Tests.MsmqSubscriptionStorageIntegrationTests";
+        const string TestQueueName = "NServiceBus.Core.Tests.MsmqSubscriptionStorageIntegrationTests";
 
         [SetUp]
         public void Setup()
         {
-            DeleteQueueIfPresent(testQueueName);
+            DeleteQueueIfPresent(TestQueueName);
         }
 
         [TearDown]
         public void TearDown()
         {
-            DeleteQueueIfPresent(testQueueName);
+            DeleteQueueIfPresent(TestQueueName);
         }
 
         [Test]
         public async Task ShouldRemoveSubscriptionsInTransactionalMode()
         {
-            var address = MsmqAddress.Parse(testQueueName);
+            var address = MsmqAddress.Parse(TestQueueName);
             var queuePath = address.PathWithoutPrefix;
 
             MessageQueue.Create(queuePath, true);
@@ -45,7 +46,7 @@
 
             storage.Init();
 
-            await storage.Unsubscribe(new Subscriber("subscriber", "subscriber"), new MessageType(typeof(MyMessage)), new ContextBag());
+            await storage.Unsubscribe(new Subscriber("subscriber", "subscriber"), new MessageType(typeof(MyMessage)), new ContextBag(), CancellationToken.None);
 
             using (var queue = new MessageQueue(queuePath))
             {
@@ -56,7 +57,7 @@
         [Test]
         public async Task ShouldRemoveSubscriptionsInNonTransactionalMode()
         {
-            var address = MsmqAddress.Parse(testQueueName);
+            var address = MsmqAddress.Parse(TestQueueName);
             var queuePath = address.PathWithoutPrefix;
 
             MessageQueue.Create(queuePath, false);
@@ -74,7 +75,7 @@
 
             storage.Init();
 
-            await storage.Unsubscribe(new Subscriber("subscriber", "subscriber"), new MessageType(typeof(MyMessage)), new ContextBag());
+            await storage.Unsubscribe(new Subscriber("subscriber", "subscriber"), new MessageType(typeof(MyMessage)), new ContextBag(), CancellationToken.None);
 
             using (var queue = new MessageQueue(queuePath))
             {

--- a/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/Persistence/MsmqSubscriptionStorageTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using NServiceBus.Persistence.Msmq;
@@ -20,14 +21,14 @@
             var messageType = new MessageType(typeof(SomeMessage));
             var storage = CreateAndInit(queue);
 
-            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub2", "endpointA"), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub2", "endpointA"), messageType, new ContextBag(), CancellationToken.None);
 
             var storedMessages = queue.GetAllMessages().ToArray();
             Assert.That(storedMessages.Length, Is.EqualTo(2));
 
             storage = CreateAndInit(queue);
-            var subscribers = (await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag())).ToArray();
+            var subscribers = (await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag(), CancellationToken.None)).ToArray();
             Assert.That(subscribers, Has.Exactly(1).Matches<Subscriber>(s => s.TransportAddress == "sub1" && s.Endpoint == null));
             Assert.That(subscribers, Has.Exactly(1).Matches<Subscriber>(s => s.TransportAddress == "sub2" && s.Endpoint == "endpointA"));
         }
@@ -39,14 +40,14 @@
             var storage = CreateAndInit(queue);
 
             var messageType = new MessageType(typeof(SomeMessage));
-            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag(), CancellationToken.None);
             storage = CreateAndInit(queue);
 
-            await storage.Unsubscribe(new Subscriber("sub1", "endpointA"), messageType, new ContextBag());
+            await storage.Unsubscribe(new Subscriber("sub1", "endpointA"), messageType, new ContextBag(), CancellationToken.None);
             Assert.That(queue.GetAllMessages(), Is.Empty);
 
             storage = CreateAndInit(queue);
-            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag(), CancellationToken.None);
             Assert.AreEqual(0, subscribers.Count());
         }
 
@@ -57,12 +58,12 @@
             var storage = CreateAndInit(queue);
 
             var messageType = new MessageType(typeof(SomeMessage));
-            await storage.Subscribe(new Subscriber("sub1", "1"), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", "2"), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", "3"), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", "1"), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub1", "2"), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub1", "3"), messageType, new ContextBag(), CancellationToken.None);
 
             storage = CreateAndInit(queue);
-            var subscribers = (await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag())).ToArray();
+            var subscribers = (await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag(), CancellationToken.None)).ToArray();
 
             Assert.That(subscribers.Length, Is.EqualTo(1));
             Assert.That(subscribers[0].TransportAddress, Is.EqualTo("sub1"));
@@ -77,10 +78,10 @@
             var storage = CreateAndInit(queue);
 
             var messageType = new MessageType(typeof(SomeMessage));
-            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("SUB1", null), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("SUB1", null), messageType, new ContextBag(), CancellationToken.None);
 
-            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag(), CancellationToken.None);
             Assert.AreEqual(1, subscribers.Count());
         }
 
@@ -91,10 +92,10 @@
             var storage = CreateAndInit(queue);
 
             var messageType = new MessageType(typeof(SomeMessage));
-            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub2", null), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub2", null), messageType, new ContextBag(), CancellationToken.None);
 
-            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { messageType }, new ContextBag(), CancellationToken.None);
             Assert.AreEqual(2, subscribers.Count());
         }
 
@@ -106,10 +107,10 @@
 
             var messageType = new MessageType(typeof(SomeMessage));
             var messageTypes = new[] { messageType };
-            await storage.Subscribe(new Subscriber("legacy", null), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("new", "endpoint"), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("legacy", null), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("new", "endpoint"), messageType, new ContextBag(), CancellationToken.None);
 
-            var subscribers = (await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag())).ToArray();
+            var subscribers = (await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag(), CancellationToken.None)).ToArray();
 
             Assert.AreEqual(2, subscribers.Length);
             Assert.IsTrue(subscribers.Any(s => s.TransportAddress == "legacy" && s.Endpoint == null));
@@ -124,13 +125,13 @@
 
             var someMessageType = new MessageType(typeof(SomeMessage));
             var otherMessageType = new MessageType(typeof(OtherMessage));
-            await storage.Subscribe(new Subscriber("sub1", null), someMessageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", null), otherMessageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), someMessageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub1", null), otherMessageType, new ContextBag(), CancellationToken.None);
 
-            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { someMessageType }, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { someMessageType }, new ContextBag(), CancellationToken.None);
             Assert.AreEqual(1, subscribers.Count());
 
-            subscribers = await storage.GetSubscriberAddressesForMessage(new[] { otherMessageType }, new ContextBag());
+            subscribers = await storage.GetSubscriberAddressesForMessage(new[] { otherMessageType }, new ContextBag(), CancellationToken.None);
             Assert.AreEqual(1, subscribers.Count());
         }
 
@@ -142,14 +143,14 @@
 
             var someMessageType = new MessageType(typeof(SomeMessage));
             var otherMessageType = new MessageType(typeof(OtherMessage));
-            await storage.Subscribe(new Subscriber("sub1", null), someMessageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", null), otherMessageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), someMessageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub1", null), otherMessageType, new ContextBag(), CancellationToken.None);
 
             var subscribers = await storage.GetSubscriberAddressesForMessage(new[]
             {
                 someMessageType,
                 otherMessageType
-            }, new ContextBag());
+            }, new ContextBag(), CancellationToken.None);
 
             Assert.AreEqual(1, subscribers.Count());
         }
@@ -162,10 +163,10 @@
 
             var messageType = new MessageType(typeof(SomeMessage));
             var messageTypes = new[] { messageType };
-            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", "endpoint"), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub1", "endpoint"), messageType, new ContextBag(), CancellationToken.None);
 
-            var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag(), CancellationToken.None);
 
             var subscriber = subscribers.Single();
             Assert.AreEqual("sub1", subscriber.TransportAddress);
@@ -180,12 +181,12 @@
 
             var messageType = new MessageType(typeof(SomeMessage));
             var messageTypes = new[] { messageType };
-            await storage.Subscribe(new Subscriber("sub1", "e1"), messageType, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", "e2"), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", "e1"), messageType, new ContextBag(), CancellationToken.None);
+            await storage.Subscribe(new Subscriber("sub1", "e2"), messageType, new ContextBag(), CancellationToken.None);
 
-            await storage.Unsubscribe(new Subscriber("sub1", "e3"), messageType, new ContextBag());
+            await storage.Unsubscribe(new Subscriber("sub1", "e3"), messageType, new ContextBag(), CancellationToken.None);
 
-            var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag(), CancellationToken.None);
             Assert.AreEqual(0, subscribers.Count());
         }
 
@@ -254,7 +255,7 @@
             var subscribers = await subscriptionStorage.GetSubscriberAddressesForMessage(new[]
             {
                 new MessageType("SomeMessage", "2.0.0")
-            }, new ContextBag());
+            }, new ContextBag(), CancellationToken.None);
 
             Assert.AreEqual("subscriberA", subscribers.Single().Endpoint);
         }

--- a/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/ConfigureMsmqTransportInfrastructure.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Messaging;
+using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Transport;
@@ -21,18 +22,19 @@ class ConfigureMsmqTransportInfrastructure : IConfigureTransportInfrastructure
         return msmqSettings;
     }
 
-    public async Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName, string errorQueueName)
+    public async Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName, string errorQueueName, CancellationToken cancellationToken)
     {
         var msmqSettings = (MsmqTransport)transportDefinition;
         receiveQueue = inputQueueName;
         var infrastructure = await msmqSettings.Initialize(hostSettings,
             new[] { new ReceiveSettings("TestReceiver", inputQueueName, false, true, errorQueueName) },
-            new[] { errorQueueName });
+            new[] { errorQueueName },
+            cancellationToken);
 
         return infrastructure;
     }
 
-    public Task Cleanup()
+    public Task Cleanup(CancellationToken cancellationToken)
     {
         var allQueues = MessageQueue.GetPrivateQueuesByMachine("localhost");
         var queuesToBeDeleted = new List<string>();

--- a/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.842" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.852" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.Msmq/InstanceMapping/InstanceMappingFileMonitor.cs
+++ b/src/NServiceBus.Transport.Msmq/InstanceMapping/InstanceMappingFileMonitor.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Transport.Msmq
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Features;
     using Logging;
@@ -21,10 +22,10 @@ namespace NServiceBus.Transport.Msmq
 
         internal Task Start(IMessageSession session)
         {
-            return OnStart(session);
+            return OnStart(session, CancellationToken.None);
         }
 
-        protected override Task OnStart(IMessageSession session)
+        protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
         {
             timer.Start(() =>
             {
@@ -97,7 +98,7 @@ namespace NServiceBus.Transport.Msmq
             return count > 1 ? $"{count} instances" : $"{count} instance";
         }
 
-        protected override Task OnStop(IMessageSession session) => timer.Stop();
+        protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken) => timer.Stop();
 
         TimeSpan checkInterval;
         IInstanceMappingLoader loader;

--- a/src/NServiceBus.Transport.Msmq/MessagePump.cs
+++ b/src/NServiceBus.Transport.Msmq/MessagePump.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.Transport.Msmq
         public MessagePump(
             Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory,
             TimeSpan messageEnumeratorTimeout,
-            Action<string, Exception> criticalErrorAction,
+            Action<string, Exception, CancellationToken> criticalErrorAction,
             MsmqTransport transportSettings,
             ReceiveSettings receiveSettings)
         {
@@ -33,12 +33,12 @@ namespace NServiceBus.Transport.Msmq
             cancellationTokenSource?.Dispose();
         }
 
-        public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError)
+        public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, CancellationToken cancellationToken)
         {
             peekCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("MsmqPeek", TimeSpan.FromSeconds(30),
-                ex => criticalErrorAction("Failed to peek " + receiveSettings.ReceiveAddress, ex));
+                ex => criticalErrorAction("Failed to peek " + receiveSettings.ReceiveAddress, ex, CancellationToken.None));
             receiveCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("MsmqReceive", TimeSpan.FromSeconds(30),
-                ex => criticalErrorAction("Failed to receive from " + receiveSettings.ReceiveAddress, ex));
+                ex => criticalErrorAction("Failed to receive from " + receiveSettings.ReceiveAddress, ex, CancellationToken.None));
 
             var inputAddress = MsmqAddress.Parse(receiveSettings.ReceiveAddress);
             var errorAddress = MsmqAddress.Parse(receiveSettings.ErrorQueue);
@@ -74,7 +74,7 @@ namespace NServiceBus.Transport.Msmq
             return TaskEx.CompletedTask;
         }
 
-        public Task StartReceive()
+        public Task StartReceive(CancellationToken cancellationToken)
         {
             MessageQueue.ClearConnectionCache();
 
@@ -87,7 +87,7 @@ namespace NServiceBus.Transport.Msmq
             return Task.CompletedTask;
         }
 
-        public async Task StopReceive()
+        public async Task StopReceive(CancellationToken cancellationToken)
         {
             cancellationTokenSource.Cancel();
 
@@ -247,7 +247,7 @@ namespace NServiceBus.Transport.Msmq
         RepeatedFailuresOverTimeCircuitBreaker receiveCircuitBreaker;
         Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory;
         TimeSpan messageEnumeratorTimeout;
-        readonly Action<string, Exception> criticalErrorAction;
+        readonly Action<string, Exception, CancellationToken> criticalErrorAction;
         readonly MsmqTransport transportSettings;
         readonly ReceiveSettings receiveSettings;
 

--- a/src/NServiceBus.Transport.Msmq/MessagePump.cs
+++ b/src/NServiceBus.Transport.Msmq/MessagePump.cs
@@ -79,7 +79,7 @@ namespace NServiceBus.Transport.Msmq
             MessageQueue.ClearConnectionCache();
 
             cancellationTokenSource = new CancellationTokenSource();
-            cancellationToken = cancellationTokenSource.Token;
+            this.cancellationToken = cancellationTokenSource.Token;
 
             // LongRunning is useless combined with async/await
             messagePumpTask = Task.Run(() => ProcessMessages(), CancellationToken.None);

--- a/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Transport.Msmq
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Messaging;
+    using System.Threading;
     using System.Threading.Tasks;
     using System.Transactions;
     using Performance.TimeToBeReceived;
@@ -19,7 +20,7 @@ namespace NServiceBus.Transport.Msmq
             this.transportSettings = transportSettings;
         }
 
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
         {
             Guard.AgainstNull(nameof(outgoingMessages), outgoingMessages);
 

--- a/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Linq;
     using System.Messaging;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using System.Transactions;
     using Features;
@@ -26,7 +27,7 @@ namespace NServiceBus
         }
 
         /// <inheritdoc />
-        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses)
+        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
         {
             Guard.AgainstNull(nameof(hostSettings), hostSettings);
             Guard.AgainstNull(nameof(receivers), receivers);

--- a/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.Msmq
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using System.Transactions;
     using Transport;
@@ -34,7 +35,7 @@ namespace NServiceBus.Transport.Msmq
             }
         }
 
-        public void SetupReceivers(ReceiveSettings[] receivers, Action<string, Exception> criticalErrorAction)
+        public void SetupReceivers(ReceiveSettings[] receivers, Action<string, Exception, CancellationToken> criticalErrorAction)
         {
             var messagePumps = new Dictionary<string, IMessageReceiver>(receivers.Length);
 
@@ -62,7 +63,7 @@ namespace NServiceBus.Transport.Msmq
             Receivers = messagePumps;
         }
 
-        public override Task Shutdown()
+        public override Task Shutdown(CancellationToken cancellationToken)
         {
             foreach (var receiver in Receivers.Values)
             {

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.852" />
     <PackageReference Include="Particular.Packaging" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/Persistence/SubscriptionStorage/MsmqSubscriptionStorage.cs
@@ -62,7 +62,7 @@ namespace NServiceBus.Persistence.Msmq
             }
         }
 
-        public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context)
+        public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken)
         {
             var messagelist = messageTypes.ToArray();
             var result = new HashSet<Subscriber>();
@@ -91,7 +91,7 @@ namespace NServiceBus.Persistence.Msmq
             return Task.FromResult<IEnumerable<Subscriber>>(result);
         }
 
-        public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
+        public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
         {
             var body = $"{messageType.TypeName}, Version={messageType.Version}";
             var label = Serialize(subscriber);
@@ -104,7 +104,7 @@ namespace NServiceBus.Persistence.Msmq
             return TaskEx.CompletedTask;
         }
 
-        public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
+        public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
         {
             var messageId = RemoveFromLookup(subscriber, messageType);
 


### PR DESCRIPTION
Adding the mandatory `CancellationToken` parameters and passing `CancellationToken.None` to all methods that require a cancellation token now. The actual usage of the tokens will be corrected by the related TF.

cc @andreasohlund 