### PR TITLE
Update to NServiceBus Core alpha 880

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.880" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqFailureInfoStorageTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqFailureInfoStorageTests.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.Msmq.Tests
 {
     using System;
     using System.Collections.Generic;
+    using Extensibility;
     using NUnit.Framework;
 
     public class MsmqFailureInfoStorageTests
@@ -14,7 +15,7 @@ namespace NServiceBus.Transport.Msmq.Tests
 
             var storage = GetFailureInfoStorage();
 
-            storage.RecordFailureInfoForMessage(messageId, exception);
+            storage.RecordFailureInfoForMessage(messageId, exception, new ContextBag());
 
             storage.TryGetFailureInfoForMessage(messageId, out var failureInfo);
 
@@ -31,8 +32,8 @@ namespace NServiceBus.Transport.Msmq.Tests
 
             var storage = GetFailureInfoStorage();
 
-            storage.RecordFailureInfoForMessage(messageId, new Exception());
-            storage.RecordFailureInfoForMessage(messageId, secondException);
+            storage.RecordFailureInfoForMessage(messageId, new Exception(), new ContextBag());
+            storage.RecordFailureInfoForMessage(messageId, secondException, new ContextBag());
 
             storage.TryGetFailureInfoForMessage(messageId, out var failureInfo);
 
@@ -48,7 +49,7 @@ namespace NServiceBus.Transport.Msmq.Tests
 
             var storage = GetFailureInfoStorage();
 
-            storage.RecordFailureInfoForMessage(messageId, new Exception());
+            storage.RecordFailureInfoForMessage(messageId, new Exception(), new ContextBag());
 
             storage.TryGetFailureInfoForMessage(messageId, out var failureInfo);
             Assert.NotNull(failureInfo);
@@ -62,19 +63,19 @@ namespace NServiceBus.Transport.Msmq.Tests
         [Test]
         public void When_recording_more_than_max_number_of_failures_should_remove_least_recently_used_entry()
         {
-            const int MaxElements = 50;
-            var storage = new MsmqFailureInfoStorage(maxElements: MaxElements);
+            const int maxElements = 50;
+            var storage = new MsmqFailureInfoStorage(maxElements: maxElements);
 
             var lruMessageId = Guid.NewGuid().ToString("D");
 
-            storage.RecordFailureInfoForMessage(lruMessageId, new Exception());
+            storage.RecordFailureInfoForMessage(lruMessageId, new Exception(), new ContextBag());
 
-            for (var i = 0; i < MaxElements; ++i)
+            for (var i = 0; i < maxElements; ++i)
             {
                 var messageId = Guid.NewGuid().ToString("D");
                 var exception = new Exception();
 
-                storage.RecordFailureInfoForMessage(messageId, exception);
+                storage.RecordFailureInfoForMessage(messageId, exception, new ContextBag());
             }
 
             storage.TryGetFailureInfoForMessage(lruMessageId, out var failureInfo);
@@ -85,27 +86,27 @@ namespace NServiceBus.Transport.Msmq.Tests
         [Test]
         public void When_recording_a_failure_for_a_message_it_should_not_be_treated_as_least_recently_used()
         {
-            const int MaxElements = 50;
-            var storage = new MsmqFailureInfoStorage(MaxElements);
+            const int maxElements = 50;
+            var storage = new MsmqFailureInfoStorage(maxElements);
 
             var lruMessageId = Guid.NewGuid().ToString("D");
 
-            storage.RecordFailureInfoForMessage(lruMessageId, new Exception());
+            storage.RecordFailureInfoForMessage(lruMessageId, new Exception(), new ContextBag());
 
-            var messageIds = new List<string>(MaxElements);
-            for (var i = 0; i < MaxElements; ++i)
+            var messageIds = new List<string>(maxElements);
+            for (var i = 0; i < maxElements; ++i)
             {
                 messageIds.Add(Guid.NewGuid().ToString("D"));
             }
 
-            for (var i = 0; i < MaxElements - 1; ++i)
+            for (var i = 0; i < maxElements - 1; ++i)
             {
-                storage.RecordFailureInfoForMessage(messageIds[i], new Exception());
+                storage.RecordFailureInfoForMessage(messageIds[i], new Exception(), new ContextBag());
             }
 
-            storage.RecordFailureInfoForMessage(lruMessageId, new Exception());
+            storage.RecordFailureInfoForMessage(lruMessageId, new Exception(), new ContextBag());
 
-            storage.RecordFailureInfoForMessage(messageIds[MaxElements - 1], new Exception());
+            storage.RecordFailureInfoForMessage(messageIds[maxElements - 1], new Exception(), new ContextBag());
 
             storage.TryGetFailureInfoForMessage(lruMessageId, out var failureInfo);
 

--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.880" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.152" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.880" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.Msmq/MsmqFailureInfoStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqFailureInfoStorage.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.Msmq
     using System;
     using System.Collections.Generic;
     using System.Runtime.ExceptionServices;
+    using Extensibility;
 
     // The data structure has fixed maximum size. When the data structure reaches its maximum size,
     // the least recently used (LRU) message processing failure is removed from the storage.
@@ -13,14 +14,14 @@ namespace NServiceBus.Transport.Msmq
             this.maxElements = maxElements;
         }
 
-        public void RecordFailureInfoForMessage(string messageId, Exception exception)
+        public void RecordFailureInfoForMessage(string messageId, Exception exception, ContextBag context)
         {
             lock (lockObject)
             {
                 if (failureInfoPerMessage.TryGetValue(messageId, out var node))
                 {
                     // We have seen this message before, just update the counter and store exception.
-                    node.FailureInfo = new ProcessingFailureInfo(node.FailureInfo.NumberOfProcessingAttempts + 1, ExceptionDispatchInfo.Capture(exception));
+                    node.FailureInfo = new ProcessingFailureInfo(node.FailureInfo.NumberOfProcessingAttempts + 1, ExceptionDispatchInfo.Capture(exception), context);
 
                     // Maintain invariant: leastRecentlyUsedMessages.First contains the LRU item.
                     leastRecentlyUsedMessages.Remove(node.LeastRecentlyUsedEntry);
@@ -38,7 +39,7 @@ namespace NServiceBus.Transport.Msmq
 
                     var newNode = new FailureInfoNode(
                         messageId,
-                        new ProcessingFailureInfo(1, ExceptionDispatchInfo.Capture(exception)));
+                        new ProcessingFailureInfo(1, ExceptionDispatchInfo.Capture(exception), context));
 
                     failureInfoPerMessage[messageId] = newNode;
 
@@ -92,13 +93,15 @@ namespace NServiceBus.Transport.Msmq
 
         public class ProcessingFailureInfo
         {
-            public ProcessingFailureInfo(int numberOfProcessingAttempts, ExceptionDispatchInfo exceptionDispatchInfo)
+            public ProcessingFailureInfo(int numberOfProcessingAttempts, ExceptionDispatchInfo exceptionDispatchInfo, ContextBag contextBag)
             {
                 NumberOfProcessingAttempts = numberOfProcessingAttempts;
                 ExceptionDispatchInfo = exceptionDispatchInfo;
+                ContextBag = contextBag;
             }
 
             public int NumberOfProcessingAttempts { get; }
+            public ContextBag ContextBag { get; set; }
             public Exception Exception => ExceptionDispatchInfo.SourceException;
             ExceptionDispatchInfo ExceptionDispatchInfo { get; }
         }

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.880" />
     <PackageReference Include="Particular.Packaging" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.Msmq/NoTransactionStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/NoTransactionStrategy.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.Msmq
     using System;
     using System.Messaging;
     using System.Threading.Tasks;
+    using Extensibility;
     using Transport;
 
     class NoTransactionStrategy : ReceiveStrategy
@@ -22,17 +23,18 @@ namespace NServiceBus.Transport.Msmq
 
             var transportTransaction = new TransportTransaction();
 
+            var context = new ContextBag();
             using (var bodyStream = message.BodyStream)
             {
                 try
                 {
-                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction, context).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {
                     message.BodyStream.Position = 0;
 
-                    await HandleError(message, exception, transportTransaction, 1).ConfigureAwait(false);
+                    await HandleError(message, exception, transportTransaction, 1, context).ConfigureAwait(false);
                 }
             }
         }

--- a/src/NServiceBus.Transport.Msmq/ReceiveOnlyNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/ReceiveOnlyNativeTransactionStrategy.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Messaging;
     using System.Threading.Tasks;
+    using Extensibility;
     using Transport;
 
     class ReceiveOnlyNativeTransactionStrategy : ReceiveStrategy
@@ -16,7 +17,7 @@
         public override async Task ReceiveMessage()
         {
             Message message = null;
-
+            var context = new ContextBag();
             try
             {
                 using (var msmqTransaction = new MessageQueueTransaction())
@@ -36,7 +37,7 @@
                         return;
                     }
 
-                    var shouldCommit = await ProcessMessage(message, headers).ConfigureAwait(false);
+                    var shouldCommit = await ProcessMessage(message, headers, context).ConfigureAwait(false);
 
                     if (shouldCommit)
                     {
@@ -58,15 +59,15 @@
                     throw;
                 }
 
-                failureInfoStorage.RecordFailureInfoForMessage(message.Id, exception);
+                failureInfoStorage.RecordFailureInfoForMessage(message.Id, exception, context);
             }
         }
 
-        async Task<bool> ProcessMessage(Message message, Dictionary<string, string> headers)
+        async Task<bool> ProcessMessage(Message message, Dictionary<string, string> headers, ContextBag contextBag)
         {
             if (failureInfoStorage.TryGetFailureInfoForMessage(message.Id, out var failureInfo))
             {
-                var errorHandleResult = await HandleError(message, failureInfo.Exception, transportTransaction, failureInfo.NumberOfProcessingAttempts).ConfigureAwait(false);
+                var errorHandleResult = await HandleError(message, failureInfo.Exception, transportTransaction, failureInfo.NumberOfProcessingAttempts, failureInfo.ContextBag).ConfigureAwait(false);
 
                 if (errorHandleResult == ErrorHandleResult.Handled)
                 {
@@ -78,13 +79,13 @@
             {
                 using (var bodyStream = message.BodyStream)
                 {
-                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction, contextBag).ConfigureAwait(false);
                 }
                 return true;
             }
             catch (Exception exception)
             {
-                failureInfoStorage.RecordFailureInfoForMessage(message.Id, exception);
+                failureInfoStorage.RecordFailureInfoForMessage(message.Id, exception, contextBag);
 
                 return false;
             }

--- a/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
@@ -100,7 +100,7 @@ namespace NServiceBus.Transport.Msmq
             errorQueue.Send(message, transactionType);
         }
 
-        protected async Task TryProcessMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction)
+        protected async Task TryProcessMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction, ContextBag contextBag)
         {
             if (!ignoreIncomingTimeToBeReceivedHeaders && TimeToBeReceived.HasElapsed(headers))
             {
@@ -109,19 +109,19 @@ namespace NServiceBus.Transport.Msmq
             }
 
             var body = await ReadStream(bodyStream).ConfigureAwait(false);
-            var messageContext = new MessageContext(messageId, headers, body, transaction, new ContextBag());
+            var messageContext = new MessageContext(messageId, headers, body, transaction, contextBag);
 
             await onMessage(messageContext, CancellationToken.None).ConfigureAwait(false);
         }
 
-        protected async Task<ErrorHandleResult> HandleError(Message message, Exception exception, TransportTransaction transportTransaction, int processingAttempts)
+        protected async Task<ErrorHandleResult> HandleError(Message message, Exception exception, TransportTransaction transportTransaction, int processingAttempts, ContextBag context)
         {
             try
             {
                 var body = await ReadStream(message.BodyStream).ConfigureAwait(false);
                 var headers = MsmqUtilities.ExtractHeaders(message);
 
-                var errorContext = new ErrorContext(exception, headers, message.Id, body, transportTransaction, processingAttempts);
+                var errorContext = new ErrorContext(exception, headers, message.Id, body, transportTransaction, processingAttempts, context);
 
                 return await onError(errorContext, CancellationToken.None).ConfigureAwait(false);
             }


### PR DESCRIPTION
Implements the necessary changes to share the context with the `ErrorContext`. This needs to be carefully reviewed to ensure we use the correct context (current context for the incoming message or the stored context in the LRU storage).

I'm not sure if there are any potential side effects due to the (potentially very long) extended lifetime of the context on the `MessageContext` when storing state on the context.