### PR TITLE
[Spike] NServiceBus 8 - Scheduling Timeouts / Delayed Message with SQL as storage and using an out-of-process timeout manager

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/TestSuiteConstraints.cs
@@ -7,7 +7,7 @@
         public bool SupportsDtc => true;
         public bool SupportsCrossQueueTransactions => true;
         public bool SupportsNativePubSub => false;
-        public bool SupportsDelayedDelivery => false;
+        public bool SupportsDelayedDelivery => true;
         public bool SupportsOutbox => true;
         public bool SupportsPurgeOnStartup => true;
         public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointMsmqTransport();

--- a/src/NServiceBus.Transport.Msmq.TimeoutManager/AsyncLogger.cs
+++ b/src/NServiceBus.Transport.Msmq.TimeoutManager/AsyncLogger.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+class AsyncLogger
+{
+    static readonly BlockingCollection<(ConsoleColor, string)> Logs = new BlockingCollection<(ConsoleColor, string)>();
+
+    static AsyncLogger()
+    {
+        _ = Task.Run(MessageLoop);
+    }
+
+    static ConsoleColor current;
+
+    public static void WL(string format, params object[] args)
+    {
+        var now = DateTime.UtcNow;
+        var value = string.Format(now.ToString("s") + ": " + format, args);
+        Logs.Add((ConsoleColor.Gray, value));
+    }
+
+    public static void WL(ConsoleColor color, string format, params object[] args)
+    {
+        var now = DateTime.UtcNow;
+        var value = string.Format(now.ToString("s") + ": " + format, args);
+        Logs.Add((color, value));
+    }
+
+    static void MessageLoop()
+    {
+        while (Logs.TryTake(out var item, -1))
+        {
+            if (current != item.Item1)
+            {
+                Console.ForegroundColor = current = item.Item1;
+            }
+            Console.WriteLine(item.Item2);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.TimeoutManager/NServiceBus.Transport.Msmq.TimeoutManager.csproj
+++ b/src/NServiceBus.Transport.Msmq.TimeoutManager/NServiceBus.Transport.Msmq.TimeoutManager.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net472</TargetFramework>
+<!--        <SignAssembly>true</SignAssembly>-->
+        <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
+        <Description>MSMQ TimeoutManager</Description>
+        <OutputType>Exe</OutputType>
+        <LangVersion>8</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Reference Include="System.Messaging" />
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Dapper" Version="2.0.78" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.*" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.*" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.*" />
+        <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NServiceBus.Transport.Msmq\NServiceBus.Transport.Msmq.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Transport.Msmq.TimeoutManager/Program.cs
+++ b/src/NServiceBus.Transport.Msmq.TimeoutManager/Program.cs
@@ -1,0 +1,286 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using Dapper;
+using NServiceBus;
+using NServiceBus.Routing;
+using NServiceBus.Transport;
+using static AsyncLogger;
+
+class Program
+{
+    public static IMessageDispatcher dispatcher;
+    const string CS = "Server=.;Database=test2;Trusted_Connection=True;";
+
+    static Timer _next;
+
+    static async Task Main()
+    {
+
+        var transport = new MsmqTransport { TransportTransactionMode = TransportTransactionMode.ReceiveOnly };
+
+        var infra = await transport.Initialize(
+            new HostSettings(
+                "particular.timeoutmanager",
+                "particular.timeoutmanager",
+                new StartupDiagnosticEntries(),
+                (s, exception, arg3) => { },
+                true),
+            new[]
+            {
+                new ReceiveSettings("1", "particular.timeoutmanager", false, false,
+                    "particular.timeoutmanager.errors")
+            },
+            Array.Empty<string>()
+        ).ConfigureAwait(false);
+
+        await infra.Receivers["1"].Initialize(new PushRuntimeSettings(), OnMessage, OnError).ConfigureAwait(false);
+        await infra.Receivers["1"].StartReceive().ConfigureAwait(false);
+
+        dispatcher = infra.Dispatcher;
+
+        _next = new Timer(s => Callback(null), null, -1, -1);
+        _ = _next.Change(0, -1);
+
+        await CreateTestData()
+            .ConfigureAwait(false);
+
+        await Task.Delay(-1).ConfigureAwait(false);
+    }
+
+    static async Task CreateTestData()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var s = Stopwatch.StartNew();
+
+        var t = new List<Task>();
+        for (int i = 0; i < 1000; i++)
+        {
+            t.Add(Create(now.AddSeconds(10)));
+        }
+        await Task.WhenAll(t)
+            .ConfigureAwait(false);
+
+        WL(ConsoleColor.Magenta, "Generation took {0}", s.Elapsed);
+    }
+
+    static Task Create(DateTimeOffset at)
+    {
+        return Dispatch(Guid.NewGuid().ToString("n"),
+            new Dictionary<string, string>
+            {
+                {Expire, DateTimeOffsetHelper.ToWireFormattedString(at)}, {RouteExpiredTimeoutTo, "_test"}
+            },
+            new byte[0],
+            "particular.timeoutmanager"
+        );
+    }
+
+    static Task<ErrorHandleResult> OnError(ErrorContext context, CancellationToken cancellationToken)
+    {
+        WL(ConsoleColor.Red, "OnError");
+        return Task.FromResult(ErrorHandleResult.Handled);
+    }
+
+    static async Task OnMessage(MessageContext context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var headers = context.Headers;
+
+            var id = context.NativeMessageId;
+            var at = DateTimeOffsetHelper.ToDateTimeOffset(headers[Expire]);
+            var destination = headers[RouteExpiredTimeoutTo];
+            var body = context.Body;
+
+            headers.Remove(Expire);
+            headers.Remove(RouteExpiredTimeoutTo);
+
+            var diff = DateTime.UtcNow - at;
+
+            if (diff.Ticks > 0) // Due
+            {
+                WL("Overdue on receive ({0})", diff);
+                await Dispatch(id, headers, body, destination)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                WL("Due at {0} in {1}", at, diff);
+                await Store(id, destination, at, headers, body)
+                    .ConfigureAwait(false);
+
+                using (new TransactionScope(TransactionScopeOption.Suppress))
+                {
+                    Callback(at);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            WL("Error: {0}", e);
+            throw;
+        }
+    }
+
+
+    static async Task Store(string id, string destination, DateTimeOffset at, Dictionary<string, string> headers, byte[] body)
+    {
+        string sql = "INSERT INTO timeout (Id,Destination,Time,Headers,State) Values (@Id,@Destination,@Time,@Headers,@State);";
+
+        using var connection = new SqlConnection(CS);
+        var affectedRows = await connection.ExecuteAsync(sql,
+            new
+            {
+                Id = id,
+                Destination = destination,
+                Time = at,
+                Headers = SerializeHeaders(headers),
+                State = body
+            }).ConfigureAwait(false);
+    }
+
+    static byte[] SerializeHeaders(Dictionary<string, string> headers)
+    {
+        var s = new System.IO.MemoryStream();
+        Serializer.Serialize(s, headers);
+        return s.ToArray();
+    }
+
+    static Dictionary<string, string> DeserializerHeaders(byte[] data)
+    {
+        return Serializer.Deserialize<Dictionary<string, string>>(new MemoryStream(data, false));
+    }
+
+    public static Task Dispatch(string id, Dictionary<string, string> headers, byte[] body, string destination)
+    {
+        //WL($"Dispatch {id} to {destination}");
+        var request = new OutgoingMessage(
+            messageId: id,
+            headers: headers,
+            body: body);
+
+        var operation = new TransportOperation(
+            request,
+            new UnicastAddressTag(destination));
+
+        return dispatcher.Dispatch(
+            outgoingMessages: new TransportOperations(operation),
+            transaction: new TransportTransaction()
+        );
+    }
+
+    static readonly SemaphoreSlim s = new SemaphoreSlim(1);
+
+    static async void Callback(DateTimeOffset? at)
+    {
+        var result = s.Wait(0);
+
+        if (!result)
+        {
+            return;
+        }
+
+        try
+        {
+            if (at.HasValue && NextTimeout.HasValue && at.Value >= NextTimeout.Value)
+            {
+                return;
+            }
+
+            while (true)
+            {
+                var now = DateTime.UtcNow;
+                using var connection = new SqlConnection(CS);
+                await connection.OpenAsync().ConfigureAwait(false);
+
+                var timeouts = (await connection.QueryAsync<Timeout>(
+                    "Select top 100 * FROM timeout WITH  (updlock, rowlock) WHERE Time<@Time ORDER BY Time, Id",
+                    new { Time = now }
+                    ).ConfigureAwait(false)).ToList();
+
+                var tasks = timeouts.Select(async timeout =>
+                {
+                    using var delCon = new SqlConnection(CS);
+                    await delCon.OpenAsync().ConfigureAwait(false);
+                    using var tx = delCon.BeginTransaction();
+
+                    var diff = timeout.Time - DateTime.UtcNow;
+                    var affected = await delCon.ExecuteAsync("DELETE timeout WHERE Id = @Id", new { timeout.Id }, tx)
+                        .ConfigureAwait(false);
+
+                    if (affected != 1)
+                    {
+                        // Already dispatched
+                        return;
+                    }
+
+                    WL("Timeout {0} over due for {1}", timeout.Id, diff);
+
+                    await Dispatch(
+                            timeout.Id,
+                            DeserializerHeaders(timeout.Headers),
+                            timeout.State,
+                            timeout.Destination
+                        )
+                        .ConfigureAwait(false);
+                    tx.Commit();
+                });
+
+                await Task.WhenAll(tasks)
+                    .ConfigureAwait(false);
+
+                if (timeouts.Count == 0)
+                {
+                    var next = await connection.ExecuteScalarAsync<DateTime?>("Select top 1 Time FROM timeout ORDER BY Time")
+                        .ConfigureAwait(false);
+
+                    if (next.HasValue)
+                    {
+                        NextTimeout = new DateTimeOffset(next.Value, TimeSpan.Zero);
+                    }
+                    else
+                    {
+                        NextTimeout = null;
+                    }
+
+                    var sleep = MaxSleepDuration;
+
+                    if (NextTimeout.HasValue)
+                    {
+                        var diff = NextTimeout.Value - DateTime.UtcNow;
+                        if (diff < sleep)
+                        {
+                            sleep = diff;
+                        }
+                    }
+
+                    if (sleep.Ticks > 0)
+                    {
+                        WL("Sleep: {0}", sleep);
+                        _next.Change(sleep, System.Threading.Timeout.InfiniteTimeSpan);
+                        break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            s.Release();
+        }
+    }
+
+    static DateTimeOffset? NextTimeout;
+
+    static readonly TimeSpan MaxSleepDuration = TimeSpan.FromMinutes(1);
+
+    const string Expire = "NServiceBus.Timeout.Expire";
+    const string RouteExpiredTimeoutTo = "NServiceBus.Timeout.RouteExpiredTimeoutTo";
+}

--- a/src/NServiceBus.Transport.Msmq.TimeoutManager/Serializer.cs
+++ b/src/NServiceBus.Transport.Msmq.TimeoutManager/Serializer.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using Newtonsoft.Json;
+
+static class Serializer
+{
+    static readonly JsonSerializer JsonSerializer;
+
+    static Serializer()
+    {
+        var settings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.None,
+            DefaultValueHandling = DefaultValueHandling.Ignore
+        };
+
+        JsonSerializer = JsonSerializer.Create(settings);
+    }
+
+    public static void Serialize(Stream stream, object target)
+    {
+        using var stringWriter = new StreamWriter(stream);
+        using var jsonWriter = new JsonTextWriter(stringWriter);
+        JsonSerializer.Serialize(jsonWriter, target);
+    }
+
+    public static T Deserialize<T>(Stream stream)
+    {
+        using var reader = new StreamReader(stream);
+        using var jsonReader = new JsonTextReader(reader);
+        return JsonSerializer.Deserialize<T>(jsonReader);
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.TimeoutManager/Timeout.cs
+++ b/src/NServiceBus.Transport.Msmq.TimeoutManager/Timeout.cs
@@ -1,0 +1,10 @@
+using System;
+
+class Timeout
+{
+    public DateTime Time { get; set; }
+    public string Id { get; set; }
+    public byte[] State { get; set; }
+    public byte[] Headers { get; set; }
+    public string Destination { get; set; }
+}

--- a/src/NServiceBus.Transport.Msmq.sln
+++ b/src/NServiceBus.Transport.Msmq.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		nuget.config = nuget.config
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Transport.Msmq.TimeoutManager", "NServiceBus.Transport.Msmq.TimeoutManager\NServiceBus.Transport.Msmq.TimeoutManager.csproj", "{79D4DB9B-A268-4CD4-AE6D-0F91C9443BC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,10 @@ Global
 		{D70B5703-DB59-4F1A-B145-1A8CFCD6B3D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D70B5703-DB59-4F1A-B145-1A8CFCD6B3D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D70B5703-DB59-4F1A-B145-1A8CFCD6B3D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79D4DB9B-A268-4CD4-AE6D-0F91C9443BC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79D4DB9B-A268-4CD4-AE6D-0F91C9443BC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79D4DB9B-A268-4CD4-AE6D-0F91C9443BC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79D4DB9B-A268-4CD4-AE6D-0F91C9443BC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
@@ -22,7 +22,7 @@ namespace NServiceBus
         /// <summary>
         /// Creates a new instance of <see cref="MsmqTransport"/> for configuration.
         /// </summary>
-        public MsmqTransport() : base(TransportTransactionMode.TransactionScope, false, false, true)
+        public MsmqTransport() : base(TransportTransactionMode.TransactionScope, true, false, true)
         {
         }
 


### PR DESCRIPTION
Approach using an external timeout manager similar as in the "old" days. Scheduling logic not part of the transport itself but does have the logic to route messages that have DelayDeliveryWith or DoNotDeliverBefore properties set to a "timeouts" queue.

This timeout queue corresponds to the out-of-process timeout manager. Multiple endpoints can send delayed messages to a single timeout manager or use use multiple. Most obvious configuration would likely be a single timeout manager per machine but could also use a remote queue to have a single timeout manager per system.