### PR TITLE
Pessimistic locking plus getting rid of timer

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -9,12 +9,13 @@ using NServiceBus.AcceptanceTesting.Support;
 public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
 {
     internal readonly TestableMsmqTransport TransportDefinition = new TestableMsmqTransport();
+    public static readonly string StorageConnectionString = "Server=.;Database=nservicebus;Trusted_Connection=True;";
 
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
         TransportDefinition.UseConnectionCache = false;
         TransportDefinition.IgnoreIncomingTimeToBeReceivedHeaders = true;
-        var timeoutStorage = new SqlTimeoutStorage("Server=.;Database=nservicebus;Trusted_Connection=True;");
+        var timeoutStorage = new SqlTimeoutStorage(StorageConnectionString, tableName: "[SendingDelayedMessages.EndpointTimeouts]"); // TODO: Table name MUST NOT be set here
         TransportDefinition.DelayedDelivery = new DelayedDeliverySettings(timeoutStorage);
 
         var routingConfig = configuration.UseTransport(TransportDefinition);

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Messaging;
-using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
@@ -108,20 +108,27 @@
                 this.impl = impl;
             }
 
-            public Task Initialize(string endpointName, CancellationToken cancellationToken) => impl.Initialize(endpointName, cancellationToken);
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken) => impl.Initialize(endpointName, transactionMode, cancellationToken);
 
             public Task<DateTimeOffset?> Next() => impl.Next();
 
-            public Task Store(TimeoutItem entity)
+            public Task Store(TimeoutItem entity, TransportTransaction transaction)
             {
                 throw new Exception("Simulated");
             }
 
-            public Task<bool> Remove(TimeoutItem entity) => impl.Remove(entity);
+            public Task<bool> Remove(TimeoutItem entity, TransportTransaction transaction) => impl.Remove(entity, transaction);
 
             public Task<bool> BumpFailureCount(TimeoutItem timeout) => impl.BumpFailureCount(timeout);
 
-            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at) => impl.FetchNextDueTimeout(at);
+            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
+            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+
+            public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
+
+            public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
+
+            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
@@ -122,13 +122,13 @@
             public Task<bool> BumpFailureCount(TimeoutItem timeout) => impl.BumpFailureCount(timeout);
 
             public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
-            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+            public TransportTransaction CreateTransaction() => impl.CreateTransaction();
 
             public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
 
             public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
 
-            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
+            public Task DisposeTransaction(TransportTransaction transaction) => impl.DisposeTransaction(transaction);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -122,7 +121,7 @@
 
             public Task<bool> BumpFailureCount(TimeoutItem timeout) => impl.BumpFailureCount(timeout);
 
-            public Task<List<TimeoutItem>> FetchDueTimeouts(DateTimeOffset at) => impl.FetchDueTimeouts(at);
+            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at) => impl.FetchNextDueTimeout(at);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
@@ -93,7 +93,7 @@
                 this.context = context;
             }
 
-            public Task Initialize(string endpointName, CancellationToken cancellationToken) => impl.Initialize(endpointName, cancellationToken);
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken) => impl.Initialize(endpointName, transactionMode, cancellationToken);
 
             public async Task<DateTimeOffset?> Next()
             {
@@ -102,17 +102,24 @@
                 return next;
             }
 
-            public async Task Store(TimeoutItem entity)
+            public async Task Store(TimeoutItem entity, TransportTransaction transaction)
             {
-                await impl.Store(entity).ConfigureAwait(false);
+                await impl.Store(entity, transaction).ConfigureAwait(false);
                 context.LongTimeoutStored = true;
             }
 
-            public Task<bool> Remove(TimeoutItem entity) => impl.Remove(entity);
+            public Task<bool> Remove(TimeoutItem entity, TransportTransaction transaction) => impl.Remove(entity, transaction);
 
             public Task<bool> BumpFailureCount(TimeoutItem timeout) => impl.BumpFailureCount(timeout);
 
-            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at) => impl.FetchNextDueTimeout(at);
+            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
+            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+
+            public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
+
+            public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
+
+            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
@@ -113,13 +113,13 @@
             public Task<bool> BumpFailureCount(TimeoutItem timeout) => impl.BumpFailureCount(timeout);
 
             public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
-            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+            public TransportTransaction CreateTransaction() => impl.CreateTransaction();
 
             public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
 
             public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
 
-            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
+            public Task DisposeTransaction(TransportTransaction transaction) => impl.DisposeTransaction(transaction);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_delayed_delivery_storage_is_unavailable.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_delayed_delivery_storage_is_unavailable.cs
@@ -129,13 +129,13 @@
             public Task<bool> BumpFailureCount(TimeoutItem timeout) => impl.BumpFailureCount(timeout);
 
             public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
-            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+            public TransportTransaction CreateTransaction() => impl.CreateTransaction();
 
             public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
 
             public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
 
-            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
+            public Task DisposeTransaction(TransportTransaction transaction) => impl.DisposeTransaction(transaction);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_delayed_delivery_storage_is_unavailable.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_delayed_delivery_storage_is_unavailable.cs
@@ -115,20 +115,27 @@
                 this.impl = impl;
             }
 
-            public Task Initialize(string endpointName, CancellationToken cancellationToken) => impl.Initialize(endpointName, cancellationToken);
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken) => impl.Initialize(endpointName, transactionMode, cancellationToken);
 
             public Task<DateTimeOffset?> Next() => impl.Next();
 
-            public Task Store(TimeoutItem entity)
+            public Task Store(TimeoutItem entity, TransportTransaction transaction)
             {
                 throw new Exception("Simulated");
             }
 
-            public Task<bool> Remove(TimeoutItem entity) => impl.Remove(entity);
+            public Task<bool> Remove(TimeoutItem entity, TransportTransaction transaction) => impl.Remove(entity, transaction);
 
             public Task<bool> BumpFailureCount(TimeoutItem timeout) => impl.BumpFailureCount(timeout);
 
-            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at) => impl.FetchNextDueTimeout(at);
+            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
+            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+
+            public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
+
+            public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
+
+            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
@@ -115,13 +115,13 @@
                 this.impl = impl;
             }
 
-            public Task Initialize(string endpointName, CancellationToken cancellationToken) => impl.Initialize(endpointName, cancellationToken);
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken) => impl.Initialize(endpointName, transactionMode, cancellationToken);
 
             public Task<DateTimeOffset?> Next() => impl.Next();
 
-            public Task Store(TimeoutItem entity) => impl.Store(entity);
+            public Task Store(TimeoutItem entity, TransportTransaction transaction) => impl.Store(entity, transaction);
 
-            public Task<bool> Remove(TimeoutItem entity)
+            public Task<bool> Remove(TimeoutItem entity, TransportTransaction transaction)
             {
                 throw new Exception("Simulated");
             }
@@ -131,7 +131,14 @@
                 throw new Exception("Simulated");
             }
 
-            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at) => impl.FetchNextDueTimeout(at);
+            public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
+            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+
+            public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
+
+            public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
+
+            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
         }
 
         public class MyMessage : IMessage

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
@@ -132,13 +132,13 @@
             }
 
             public Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction) => impl.FetchNextDueTimeout(at, transaction);
-            public TransportTransaction PrepareTransaction() => impl.PrepareTransaction();
+            public TransportTransaction CreateTransaction() => impl.CreateTransaction();
 
             public Task BeginTransaction(TransportTransaction transaction) => impl.BeginTransaction(transaction);
 
             public Task CommitTransaction(TransportTransaction transaction) => impl.CommitTransaction(transaction);
 
-            public Task ReleaseTransaction(TransportTransaction transaction) => impl.ReleaseTransaction(transaction);
+            public Task DisposeTransaction(TransportTransaction transaction) => impl.DisposeTransaction(transaction);
         }
 
         public class MyMessage : IMessage

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_sending_delayed_messages.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_sending_delayed_messages.cs
@@ -1,0 +1,169 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Logging;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_delayed_messages : NServiceBusAcceptanceTest
+    {
+        [Test, Explicit]
+        [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_work_for_transaction_mode(TransportTransactionMode transactionMode)
+        {
+            Requires.DelayedDelivery();
+
+            var deliverAt = DateTimeOffset.Now.AddSeconds(10); //To ensure this timeout would never be actually dispatched during this test
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b =>
+                {
+                    b.CustomConfig(cfg => cfg.ConfigureTransport<MsmqTransport>().TransportTransactionMode = transactionMode);
+                    b.When(async (session, c) =>
+                    {
+                        var s = Stopwatch.StartNew();
+                        var sendTasks = new List<Task>(Context.NrOfDelayedMessages);
+
+                        for (int i = 0; i < Context.NrOfDelayedMessages; i++)
+                        {
+                            var options = new SendOptions();
+
+                            options.DoNotDeliverBefore(deliverAt);
+                            options.RouteToThisEndpoint();
+
+                            sendTasks.Add(session.Send(new MyMessage(), options));
+                        }
+
+                        await Task.WhenAll(sendTasks).ConfigureAwait(false);
+                        var duration = s.Elapsed;
+
+                        WL($" Sending {Context.NrOfDelayedMessages} delayed messages took {duration}.");
+                        WL(" Storing...");
+                        c.StoringTimeouts.Wait();
+                        WL($" Storing took roughly {s.Elapsed} (include sending)");
+                        WL(" Dispatching...");
+                        c.DispatchingTimeouts.Wait();
+                        var dispatchDuration = DateTimeOffset.UtcNow - deliverAt;
+                        WL($" Dispatching took {dispatchDuration}");
+                        WL(DateTime.UtcNow + " Done!");
+                    }).DoNotFailOnErrorMessages();
+                })
+                //.Done(c => c.CriticalActionCalled)
+                .Run();
+
+            //Assert.False(context.Processed);
+            //Assert.True(context.CriticalActionCalled);
+        }
+
+        static readonly ILog Log = LogManager.GetLogger<When_sending_delayed_messages>();
+
+        static void WL(string value)
+        {
+            Log.Info(value);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public const int NrOfDelayedMessages = 1000;
+            public readonly CountdownEvent StoringTimeouts = new CountdownEvent(NrOfDelayedMessages);
+            public readonly CountdownEvent DispatchingTimeouts = new CountdownEvent(NrOfDelayedMessages);
+            public readonly CountdownEvent Processed = new CountdownEvent(NrOfDelayedMessages);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
+                {
+                    var context = (Context)run.ScenarioContext;
+                    var transport = endpointConfiguration.ConfigureTransport<MsmqTransport>();
+                    //transport.TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
+
+                    var storage = new WrapTimeoutStorage(transport.DelayedDelivery.TimeoutStorage, context);
+                    transport.DelayedDelivery = new DelayedDeliverySettings(
+                        storage,
+                        2,
+                        TimeSpan.FromSeconds(5)
+                        );
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Processed.Signal();
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        class WrapTimeoutStorage : ITimeoutStorage
+        {
+            ITimeoutStorage timeoutStorageImplementation;
+            Context context;
+
+            public WrapTimeoutStorage(ITimeoutStorage impl, Context context)
+            {
+                this.context = context;
+                timeoutStorageImplementation = impl;
+            }
+
+            public Task Initialize(string endpointName, CancellationToken cancellationToken) => timeoutStorageImplementation.Initialize(endpointName, cancellationToken);
+
+            public Task<DateTimeOffset?> Next() => timeoutStorageImplementation.Next();
+
+            public Task Store(TimeoutItem entity)
+            {
+                System.Transactions.Transaction.Current.TransactionCompleted += (s, e) => context.StoringTimeouts.Signal();
+                return timeoutStorageImplementation.Store(entity);
+            }
+
+            public Task<bool> Remove(TimeoutItem entity)
+            {
+                System.Transactions.Transaction.Current.TransactionCompleted += (s, e) => context.DispatchingTimeouts.Signal();
+                return timeoutStorageImplementation.Remove(entity);
+            }
+
+            public Task<bool> BumpFailureCount(TimeoutItem timeout) => timeoutStorageImplementation.BumpFailureCount(timeout);
+
+            public Task<List<TimeoutItem>> FetchDueTimeouts(DateTimeOffset at) => timeoutStorageImplementation.FetchDueTimeouts(at);
+        }
+
+        class FakeTimeoutStorage : ITimeoutStorage
+        {
+            public Task Initialize(string endpointName, CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task<DateTimeOffset?> Next() => Task.FromResult((DateTimeOffset?)DateTimeOffset.UtcNow.AddYears(1));
+
+            public Task Store(TimeoutItem entity) => Task.CompletedTask;
+
+            public Task<bool> Remove(TimeoutItem entity) => Task.FromResult(true);
+
+            public Task<bool> BumpFailureCount(TimeoutItem timeout) => Task.FromResult(true);
+
+            public Task<List<TimeoutItem>> FetchDueTimeouts(DateTimeOffset at) => Task.FromResult(new List<TimeoutItem>(0));
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_sending_delayed_messages.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_sending_delayed_messages.cs
@@ -58,17 +58,17 @@
                         await Task.WhenAll(sendTasks).ConfigureAwait(false);
                         var duration = s.Elapsed;
 
-                        Log.InfoFormat(($" Sending {Context.NrOfDelayedMessages} delayed messages took {duration}.");
-                        Log.InfoFormat(("Storing...");
+                        Log.InfoFormat($" Sending {Context.NrOfDelayedMessages} delayed messages took {duration}.");
+                        Log.InfoFormat("Storing...");
                         c.StoringTimeouts.Wait();
-                        Log.InfoFormat(($" Storing took roughly {s.Elapsed} (include sending)");
-                        Log.InfoFormat(("Dispatching...");
+                        Log.InfoFormat($" Storing took roughly {s.Elapsed} (include sending)");
+                        Log.InfoFormat("Dispatching...");
                         c.DispatchingTimeouts.Wait();
                         var dispatchDuration = DateTimeOffset.UtcNow - deliverAt;
-                        Log.InfoFormat(($" Dispatching took {dispatchDuration}");
-                        Log.InfoFormat(("Processing...");
+                        Log.InfoFormat($" Dispatching took {dispatchDuration}");
+                        Log.InfoFormat("Processing...");
                         c.Processed.Wait();
-                        Log.InfoFormat(("Done!");
+                        Log.InfoFormat("Done!");
                         var affected = await PurgeTimeoutsTable().ConfigureAwait(false);
                         Assert.AreEqual(0, affected, "No rows should remain in database.");
                     }).DoNotFailOnErrorMessages();

--- a/src/NServiceBus.Transport.Msmq/DelayedDeliveryPump.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDeliveryPump.cs
@@ -95,7 +95,7 @@ namespace NServiceBus.Transport.Msmq
                     throw new Exception("Error while storing delayed message", e);
                 }
 
-                poller.Callback(timeout.Time);
+                poller.Signal(timeout.Time);
             }
         }
 

--- a/src/NServiceBus.Transport.Msmq/DelayedDeliveryPump.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDeliveryPump.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Transport.Msmq
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Logging;
     using Routing;
 
     class DelayedDeliveryPump
@@ -16,6 +17,7 @@ namespace NServiceBus.Transport.Msmq
         readonly Dictionary<string, string> faultMetadata;
         readonly string errorQueue;
         RepeatedFailuresOverTimeCircuitBreaker storeCircuitBreaker;
+        readonly ILog Log = LogManager.GetLogger<DelayedDeliveryPump>();
 
         public DelayedDeliveryPump(MsmqMessageDispatcher dispatcher,
             TimeoutPoller poller,
@@ -108,6 +110,8 @@ namespace NServiceBus.Transport.Msmq
 
         async Task<ErrorHandleResult> OnError(ErrorContext errorContext, CancellationToken cancellationToken)
         {
+            Log.Error($"OnError {errorContext.Message.MessageId}", errorContext.Exception);
+
             if (errorContext.ImmediateProcessingFailures < numberOfRetries)
             {
                 return ErrorHandleResult.RetryRequired;

--- a/src/NServiceBus.Transport.Msmq/DelayedDeliveryPump.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDeliveryPump.cs
@@ -99,7 +99,7 @@ namespace NServiceBus.Transport.Msmq
                 }
                 finally
                 {
-                    await storage.ReleaseTransaction(context.TransportTransaction).ConfigureAwait(false);
+                    await storage.DisposeTransaction(context.TransportTransaction).ConfigureAwait(false);
                 }
 
                 poller.Signal(timeout.Time);

--- a/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
+++ b/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
@@ -1,0 +1,53 @@
+namespace NServiceBus.Transport.Msmq
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Logging;
+
+    class FailureRateCircuitBreaker : IDisposable
+    {
+        public FailureRateCircuitBreaker(string name, int maximumFailuresPerSecond, Action<Exception> triggerAction)
+        {
+            this.name = name;
+            this.triggerAction = triggerAction;
+            maximumFailuresPerThirtySeconds = maximumFailuresPerSecond * 30;
+            timer = new Timer(_ => FlushHistory(), null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(30));
+        }
+
+        public void Dispose()
+        {
+            timer?.Dispose();
+        }
+
+        void FlushHistory()
+        {
+            Interlocked.Exchange(ref failureCount, 0);
+            Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+        }
+
+        public void Failure(Exception lastException)
+        {
+            var result = Interlocked.Increment(ref failureCount);
+            if (result > maximumFailuresPerThirtySeconds)
+            {
+                _ = Task.Run(() =>
+                {
+                    Logger.WarnFormat("The circuit breaker for {0} will now be triggered", name);
+                    triggerAction(lastException);
+                });
+            }
+            else if (result == 1)
+            {
+                Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
+            }
+        }
+
+        static readonly ILog Logger = LogManager.GetLogger<FailureRateCircuitBreaker>();
+        readonly string name;
+        readonly Action<Exception> triggerAction;
+        readonly int maximumFailuresPerThirtySeconds;
+        readonly Timer timer;
+        long failureCount;
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
@@ -53,6 +53,7 @@ namespace NServiceBus.Transport.Msmq
             {
                 if (kvp.Key.StartsWith(MsmqUtilities.PropertyHeaderPrefix))
                 {
+                    //TODO: Remove delayed delivery properties
                     properties[kvp.Key] = kvp.Value;
                 }
                 else

--- a/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
@@ -100,6 +100,11 @@ namespace NServiceBus.Transport.Msmq
             else // transportOperation.Properties.DoNotDeliverBefore != null
             {
                 deliverAt = transportOperation.Properties.DoNotDeliverBefore.At;
+
+                if (deliverAt < DateTimeOffset.UtcNow)
+                {
+                    // TODO: Do not send to timeout queue. CHeck if core already validates this
+                }
             }
 
             transportOperation.Properties[TimeoutDestination] = transportOperation.Destination;

--- a/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
@@ -109,7 +109,7 @@ namespace NServiceBus
 
                 if (requiresDelayedDelivery)
                 {
-                    await DelayedDelivery.TimeoutStorage.Initialize(hostSettings.Name, cancellationToken).ConfigureAwait(false);
+                    await DelayedDelivery.TimeoutStorage.Initialize(hostSettings.Name, TransportTransactionMode, cancellationToken).ConfigureAwait(false);
                 }
 
                 queueCreator.CreateQueueIfNecessary(queuesToCreate);

--- a/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.Transport.Msmq
             if (delayedDeliveryPump != null)
             {
                 await delayedDeliveryPump.Stop(cancellationToken).ConfigureAwait(false);
-                timeoutPoller.Stop();
+                await timeoutPoller.Stop().ConfigureAwait(false);
             }
         }
     }

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.891, 9.0.0)" />
+    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
     <PackageReference Include="Particular.Packaging" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.Msmq/Timeouts/ITimeoutStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/ITimeoutStorage.cs
@@ -57,7 +57,7 @@ public interface ITimeoutStorage
     ///
     /// </summary>
     /// <returns></returns>
-    TransportTransaction PrepareTransaction();
+    TransportTransaction CreateTransaction();
 
     /// <summary>
     /// 
@@ -77,5 +77,5 @@ public interface ITimeoutStorage
     /// </summary>
     /// <param name="transaction"></param>
     /// <returns></returns>
-    Task ReleaseTransaction(TransportTransaction transaction);
+    Task DisposeTransaction(TransportTransaction transaction);
 }

--- a/src/NServiceBus.Transport.Msmq/Timeouts/ITimeoutStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/ITimeoutStorage.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Transport;
 
 /// <summary>
 ///
@@ -8,29 +10,34 @@ using System.Threading.Tasks;
 public interface ITimeoutStorage
 {
     /// <summary>
-    ///
+    /// 
     /// </summary>
     /// <param name="endpointName"></param>
+    /// <param name="transportTransactionMode"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task Initialize(string endpointName, CancellationToken cancellationToken);
+    Task Initialize(string endpointName, TransportTransactionMode transportTransactionMode, CancellationToken cancellationToken);
     /// <summary>
     ///
     /// </summary>
     /// <returns></returns>
     Task<DateTimeOffset?> Next();
+
     /// <summary>
-    ///
+    /// 
     /// </summary>
     /// <param name="entity"></param>
+    /// <param name="transportTransaction"></param>
     /// <returns></returns>
-    Task Store(TimeoutItem entity);
+    Task Store(TimeoutItem entity, TransportTransaction transportTransaction);
+
     /// <summary>
-    ///
+    /// 
     /// </summary>
     /// <param name="entity"></param>
+    /// <param name="transaction"></param>
     /// <returns></returns>
-    Task<bool> Remove(TimeoutItem entity);
+    Task<bool> Remove(TimeoutItem entity, TransportTransaction transaction);
 
     /// <summary>
     ///
@@ -38,20 +45,37 @@ public interface ITimeoutStorage
     /// <param name="timeout"></param>
     /// <returns></returns>
     Task<bool> BumpFailureCount(TimeoutItem timeout);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="at"></param>
+    /// <param name="transaction"></param>
+    /// <returns></returns>
+    Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at, TransportTransaction transaction);
     /// <summary>
     ///
     /// </summary>
-    /// <param name="at"></param>
     /// <returns></returns>
-    Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at);
-    ///// <summary>
-    /////
-    ///// </summary>
-    ///// <returns></returns>
-    //Task Begin();
-    ///// <summary>
-    /////
-    ///// </summary>
-    ///// <returns></returns>
-    //Task Commit();
+    TransportTransaction PrepareTransaction();
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="transaction"></param>
+    /// <returns></returns>
+    Task BeginTransaction(TransportTransaction transaction);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    Task CommitTransaction(TransportTransaction transaction);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="transaction"></param>
+    /// <returns></returns>
+    Task ReleaseTransaction(TransportTransaction transaction);
 }

--- a/src/NServiceBus.Transport.Msmq/Timeouts/ITimeoutStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/ITimeoutStorage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -44,7 +43,7 @@ public interface ITimeoutStorage
     /// </summary>
     /// <param name="at"></param>
     /// <returns></returns>
-    Task<List<TimeoutItem>> FetchDueTimeouts(DateTimeOffset at);
+    Task<TimeoutItem> FetchNextDueTimeout(DateTimeOffset at);
     ///// <summary>
     /////
     ///// </summary>

--- a/src/NServiceBus.Transport.Msmq/Timeouts/Sql/SqlTimeoutStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/Sql/SqlTimeoutStorage.cs
@@ -164,7 +164,7 @@ public class SqlTimeoutStorage : ITimeoutStorage
     }
 
     /// <inheritdoc />
-    public TransportTransaction PrepareTransaction()
+    public TransportTransaction CreateTransaction()
     {
         if (transactionMode == TransportTransactionMode.TransactionScope)
         {
@@ -229,7 +229,7 @@ public class SqlTimeoutStorage : ITimeoutStorage
     }
 
     /// <inheritdoc />
-    public Task ReleaseTransaction(TransportTransaction transaction)
+    public Task DisposeTransaction(TransportTransaction transaction)
     {
         if (transaction.TryGet(out SqlTransaction sqlTransaction))
         {

--- a/src/NServiceBus.Transport.Msmq/Timeouts/Sql/SqlTimeoutStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/Sql/SqlTimeoutStorage.cs
@@ -15,7 +15,7 @@ using IsolationLevel = System.Transactions.IsolationLevel;
 public class SqlTimeoutStorage : ITimeoutStorage
 {
     const string SqlInsert = "INSERT INTO {0} (Id, Destination, Time, Headers, State) VALUES (@id, @destination, @time, @headers, @state);";
-    const string SqlFetch = "SELECT TOP 1 Id, Destination, Time, Headers, State, RetryCount FROM {0} WITH (READPAST, UPDLOCK, ROWLOCK) WHERE Time < @time ORDER BY RetryCount, Time";
+    const string SqlFetch = "SELECT TOP 1 Id, Destination, Time, Headers, State, RetryCount FROM {0} WITH (READPAST, UPDLOCK, ROWLOCK) WHERE Time < @time ORDER BY Time";
     const string SqlDelete = "DELETE {0} WHERE Id = @id";
     const string SqlUpdate = "UPDATE {0} SET RetryCount = RetryCount + 1 WHERE Id = @id";
     const string SqlGetNext = "SELECT TOP 1 Time FROM {0} ORDER BY Time";

--- a/src/NServiceBus.Transport.Msmq/Timeouts/Sql/SqlTimeoutStorage.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/Sql/SqlTimeoutStorage.cs
@@ -79,7 +79,7 @@ public class SqlTimeoutStorage : ITimeoutStorage
     /// <inheritdoc />
     public async Task<bool> BumpFailureCount(TimeoutItem timeout)
     {
-        using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
         {
             using (var cn = await createSqlConnection().ConfigureAwait(false))
             using (var cmd = new SqlCommand(bumpFailureCountCommand, cn))

--- a/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
@@ -218,7 +218,7 @@ class TimeoutPoller
         var transportTransaction = new TransportTransaction();
         transportTransaction.Set(Transaction.Current);
 
-        TimeSpan diff = timeout.Time - DateTimeOffset.UtcNow;
+        TimeSpan diff = DateTimeOffset.UtcNow - new DateTimeOffset(timeout.Time, TimeSpan.Zero);
         var success = await timeoutStorage.Remove(timeout, transaction).ConfigureAwait(false);
 
         if (!success)

--- a/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
@@ -45,10 +45,10 @@ class TimeoutPoller
         await completionTask.ConfigureAwait(false);
     }
 
-    public void Signal(DateTime timeoutTime)
+    public void Signal(DateTimeOffset timeoutTime)
     {
-        //If the next timeout if within a minute from now, trigger the poller
-        if (DateTime.UtcNow.Add(MaxSleepDuration) > timeoutTime)
+        //If the next timeout is within a minute from now, trigger the poller
+        if (DateTimeOffset.UtcNow.Add(MaxSleepDuration) > timeoutTime)
         {
             //If there is something already in the queue we are fine.
             signalQueue.Writer.TryWrite(true);
@@ -218,7 +218,7 @@ class TimeoutPoller
         var transportTransaction = new TransportTransaction();
         transportTransaction.Set(Transaction.Current);
 
-        TimeSpan diff = timeout.Time - DateTime.UtcNow;
+        TimeSpan diff = timeout.Time - DateTimeOffset.UtcNow;
         var success = await timeoutStorage.Remove(timeout, transaction).ConfigureAwait(false);
 
         if (!success)

--- a/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
@@ -157,6 +157,7 @@ class TimeoutPoller
                 timeout = await timeoutStorage.FetchNextDueTimeout(now, tx).ConfigureAwait(false);
                 fetchCircuitBreaker.Success();
 
+                Log.Warn($"Fetch... {timeout != null}");
                 if (timeout != null)
                 {
                     result.SetResult(null);

--- a/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
@@ -148,7 +148,7 @@ class TimeoutPoller
         DateTimeOffset now = DateTimeOffset.UtcNow;
         try
         {
-            var tx = timeoutStorage.PrepareTransaction();
+            var tx = timeoutStorage.CreateTransaction();
             try
             {
                 await timeoutStorage.BeginTransaction(tx).ConfigureAwait(false);
@@ -179,7 +179,7 @@ class TimeoutPoller
             }
             finally
             {
-                await timeoutStorage.ReleaseTransaction(tx).ConfigureAwait(false);
+                await timeoutStorage.DisposeTransaction(tx).ConfigureAwait(false);
             }
         }
         catch (QueueNotFoundException exception)
@@ -245,7 +245,7 @@ class TimeoutPoller
     {
         try
         {
-            var tx = timeoutStorage.PrepareTransaction();
+            var tx = timeoutStorage.CreateTransaction();
             try
             {
                 await timeoutStorage.BeginTransaction(tx).ConfigureAwait(false);
@@ -275,7 +275,7 @@ class TimeoutPoller
             }
             finally
             {
-                await timeoutStorage.ReleaseTransaction(tx).ConfigureAwait(false);
+                await timeoutStorage.DisposeTransaction(tx).ConfigureAwait(false);
             }
         }
         catch (Exception ex)

--- a/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
+++ b/src/NServiceBus.Transport.Msmq/Timeouts/TimeoutPoller.cs
@@ -106,6 +106,7 @@ class TimeoutPoller
                 }
                 catch (Exception e)
                 {
+                    Log.Error("Failed to poll and dispatch due timeouts from storage.", e);
                     //Poll and HandleDueDelayedMessage have their own exception handling logic so any exception here is likely going to be related to the transaction itself
                     await fetchCircuitBreaker.Failure(e).ConfigureAwait(false);
                 }


### PR DESCRIPTION
I modified the storage to take advantage of the update locks. That required changing the poller to open the transaction earlier to include the fetch part. I haven't yet switched to destructive select (`DELETE...OUTPUT`) and left the `SELECT` + `DELETE` approach.

I also refactored the poller to remove the timer as my brain was cooking each time I tried to understand the `Change` logic. This approach uses two queues, one for signaling and one for completing the dispatches.

Each time we schedule a timeout in near future we `TryWrite` to the signal queue. `TryWrite` ensures there is at least single item in the queue. The `Loop` task calls the `Fetch` and `Dispatch` and then waits on `Task.Delay` **or** the signal queue, whichever happens first. 

Finally I added a new type of circuit breaker (rate-based in 30 second intervals) and wired it to failure handling. That means that if there is more than 1 error in failure handling per second the circuit breaker is going to get triggered. Added a test to verify that it works.