### PR TITLE
Add embedded timeouts to V7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,10 @@ updates:
   ignore:
     # Particular.Analyzers updates are distributed via RepoStandards
     - dependency-name: "Particular.Analyzers"
-    # Changing this dependency affects the .NET SDK and Visual Studio version supported by 
-    # a Roslyn analyzer, updates should be more intentional than an automated update
+    # Changing these 3 dependencies affects the .NET SDK and Visual Studio versions we support 
+    # These types of updates should be more intentional than an automated update
+    - dependency-name: "Microsoft.Build.Utilities.Core"
+    - dependency-name: "Microsoft.CodeAnalysis.CSharp"
     - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
     # GitVersion updates need to be manually tested and verified before updating to a newer version
     - dependency-name: "GitVersion.MsBuild"

--- a/.github/workflows/virus-scan.yml
+++ b/.github/workflows/virus-scan.yml
@@ -6,92 +6,12 @@ jobs:
   virus-scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Install ClamAV
-        run: |
-          sudo apt-get update && sudo apt-get install clamav
-          clamVersion=$(clamscan --version)
-          echo $clamVersion
-          echo "CLAMAV_VERSION=$clamVersion" >> $GITHUB_ENV
-      - name: Update virus signature database
-        run: |
-          sudo systemctl stop clamav-freshclam
-          sudo freshclam
-          sudo systemctl start clamav-freshclam
-      - name: Get release
-        uses: actions/github-script@v5
+      - name: Scan release for viruses
+        uses: Particular/virus-scan-action@main
         with:
-          github-token: ${{secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4}}
-          script: |
-            const fs = require('fs');
-            
-            await io.mkdirP('github-release-assets');
-            
-            let release = await github.repos.getReleaseByTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: '${{ github.event.release.name }}'
-            });
-            
-            core.exportVariable('RELEASE_ID', release.data.id);
-            core.exportVariable('RELEASE_BODY', release.data.body);
-            core.exportVariable('RELEASE_HTML_URL', release.data.html_url);
-            
-            for (const assetInfo of release.data.assets) {
-              let asset = await github.request(assetInfo.browser_download_url);
-              await fs.writeFile('github-release-assets/' + assetInfo.name, Buffer.from(asset.data), () => {});
-            }
-            
-            let zipball = await github.request(release.data.zipball_url);
-            await fs.writeFile('github-release-assets/source.zip', Buffer.from(zipball.data), () => {});
-            
-            let tarball = await github.request(release.data.tarball_url);
-            await fs.writeFile('github-release-assets/source.tar.gz', Buffer.from(tarball.data), () => {});
-            
-      - name: Run ClamAV
-        # Don't automatically fail on first non-zero return code by skipping -e parameter
-        # May highlight as error but docs say is valid: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell
-        shell: "/usr/bin/bash {0}"
-        run: |
-          sudo clamscan --infected github-release-assets/ > scan-results.log
-          echo "CLAMAV_RETURN_CODE=$?" >> $GITHUB_ENV
-          exit 0;
-      - name: Notify Slack on viruses detected
-        if: ${{ env.CLAMAV_RETURN_CODE == '1' }}
-        uses: 8398a7/action-slack@v3.10.0
-        with:
-          username: ClamAV Virus Scanning Workflow
-          status: failure
-          text: "ClamAV has detected a virus in the release at ${{ env.RELEASE_HTML_URL }}"
-          author_name: ""
-          fields: repo,ref,action,commit,author
-          icon_emoji: ":biohazard_sign:"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.RELEASE_ANTIVIRUS_SLACK_WEBHOOK_URL }}
-      - name: Update release notes
-        uses: actions/github-script@v5
-        with:
-          github-token: ${{secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4}}
-          script: |
-            const { CLAMAV_VERSION, CLAMAV_RETURN_CODE, RELEASE_ID, RELEASE_BODY } = process.env;
-            const fs = require('fs');
-            let status = 'No viruses detected';
-            if (CLAMAV_RETURN_CODE === '1') {
-              status = 'Virus(es) detected';
-            } else if (CLAMAV_RETURN_CODE === '2') {
-              status = 'Scanning error occurred';
-            }
-            fs.readFile('scan-results.log', { encoding: 'utf8' }, (err, fileText) => {
-            
-              console.log(fileText);
-
-              let releaseBody = RELEASE_BODY + '\n\n<details><summary><b>🛡 ClamAV virus scan results: ' + 
-                status + '</b></summary>\n\n```\nVersion: ' + CLAMAV_VERSION + 
-                '\nScan Date: ' + new Date().toUTCString() + '\n' + fileText + '\n```\n\n</details>';
-
-              github.repos.updateRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: RELEASE_ID,
-                body: releaseBody
-              });
-            });
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          tag: ${{ github.event.release.name }}
+          github-access-token: ${{ secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4 }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+          slack-channel: ${{ secrets.VIRUS_REPORTING_SLACK_CHANNEL }}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -74,5 +74,16 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
         return Task.FromResult(0);
     }
 
+    public static string GetStorageConnectionString()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("SQLServerConnectionString");
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            connectionString = @"Server=localhost\sqlexpress;Database=nservicebus;Trusted_Connection=True;";
+        }
+
+        return connectionString;
+    }
+
     QueueBindings queueBindings;
 }

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_batch_of_messages.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_batch_of_messages.cs
@@ -1,0 +1,183 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.SqlClient;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Logging;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_batch_of_messages : NServiceBusAcceptanceTest
+    {
+        static readonly TimeSpan Delay = TimeSpan.FromSeconds(25);
+        const int NrOfDelayedMessages = 1000;
+
+        [Test]
+        [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_work_for_transaction_mode(TransportTransactionMode transactionMode)
+        {
+            var deliverAt = DateTimeOffset.UtcNow + Delay; //To ensure this timeout would never be actually dispatched during this test
+
+            Log.Info($"Dispatch at {deliverAt:O}");
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b =>
+                {
+                    b.CustomConfig(cfg =>
+                    {
+                        var transport = cfg.UseTransport<MsmqTransport>();
+                        transport.Transactions(transactionMode);
+                    });
+                    b.When(async (session, c) =>
+                    {
+                        await PurgeTimeoutsTable().ConfigureAwait(false);
+
+                        var s = Stopwatch.StartNew();
+                        var sendTasks = new List<Task>(NrOfDelayedMessages);
+
+                        var limiter = new SemaphoreSlim(16);
+
+                        for (int i = 0; i < NrOfDelayedMessages; i++)
+                        {
+                            var options = new SendOptions();
+
+                            options.DoNotDeliverBefore(deliverAt);
+                            options.RouteToThisEndpoint();
+                            await limiter.WaitAsync().ConfigureAwait(false);
+                            sendTasks.Add(Task.Run(() => session.Send(new MyMessage(), options)).ContinueWith(t => limiter.Release()));
+                        }
+
+                        await Task.WhenAll(sendTasks).ConfigureAwait(false);
+                        var duration = s.Elapsed;
+
+                        Log.InfoFormat($"Sending {NrOfDelayedMessages} delayed messages took {duration}.");
+                        Log.InfoFormat("Storing...");
+                        c.StoringTimeouts.Wait();
+                        Log.InfoFormat($"Storing took roughly {s.Elapsed} (include sending)");
+
+                        Assert.Less(DateTimeOffset.UtcNow, deliverAt, "Storing not happened within timeout due timestamp");
+                        Log.InfoFormat("Dispatching...");
+                        c.DispatchingTimeouts.Wait();
+                        var dispatchDuration = DateTimeOffset.UtcNow - deliverAt;
+                        Log.InfoFormat($"Dispatching took {dispatchDuration}");
+                        Log.InfoFormat("Processing...");
+                        c.Processed.Wait();
+                        Log.InfoFormat("Done!");
+                        var affected = await PurgeTimeoutsTable().ConfigureAwait(false);
+                        Assert.AreEqual(0, affected, "No rows should remain in database.");
+                    }).DoNotFailOnErrorMessages();
+                })
+                .Run();
+        }
+
+        static async Task<int> PurgeTimeoutsTable()
+        {
+            using (var cn = new SqlConnection(ConfigureEndpointMsmqTransport.GetStorageConnectionString()))
+            {
+                await cn.OpenAsync();
+                using (var cmd = new SqlCommand($"DELETE FROM [dbo].[{Conventions.EndpointNamingConvention(typeof(Endpoint))}.timeouts]", cn))
+                {
+                    return await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public readonly CountdownEvent StoringTimeouts = new CountdownEvent(NrOfDelayedMessages);
+            public readonly CountdownEvent DispatchingTimeouts = new CountdownEvent(NrOfDelayedMessages);
+            public readonly CountdownEvent Processed = new CountdownEvent(NrOfDelayedMessages);
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
+                {
+                    var context = (Context)run.ScenarioContext;
+                    var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+
+                    var delayedDeliverySettings = transport.NativeDelayedDelivery(new WrapDelayedMessageStore(new SqlServerDelayedMessageStore(ConfigureEndpointMsmqTransport.GetStorageConnectionString()), context));
+
+                    delayedDeliverySettings.NumberOfRetries = 2;
+                    delayedDeliverySettings.TimeToTriggerStoreCircuitBreaker = TimeSpan.FromSeconds(5);
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Processed.Signal();
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        class WrapDelayedMessageStore : IDelayedMessageStore
+        {
+            readonly IDelayedMessageStore delayedMessageStoreImplementation;
+            readonly Context context;
+
+            public WrapDelayedMessageStore(IDelayedMessageStore impl, Context context)
+            {
+                this.context = context;
+                delayedMessageStoreImplementation = impl;
+            }
+
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+                => delayedMessageStoreImplementation.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
+                => delayedMessageStoreImplementation.Next(cancellationToken);
+
+            public Task Store(DelayedMessage entity, CancellationToken cancellationToken = default)
+            {
+                Transaction.Current.TransactionCompleted += (s, e) => context.StoringTimeouts.Signal();
+                return delayedMessageStoreImplementation.Store(entity, cancellationToken);
+            }
+
+            public Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default)
+                => delayedMessageStoreImplementation.IncrementFailureCount(timeout, cancellationToken);
+
+            public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default)
+                => delayedMessageStoreImplementation.Remove(entity, cancellationToken);
+
+            public async Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
+            {
+                var entity = await delayedMessageStoreImplementation.FetchNextDueTimeout(at, cancellationToken);
+
+                if (entity != null)
+                {
+                    context.DispatchingTimeouts.Signal();
+                }
+
+                return entity;
+            }
+        }
+
+        static readonly ILog Log = LogManager.GetLogger<When_deferring_a_batch_of_messages>();
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_and_storage_is_unavailable.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_and_storage_is_unavailable.cs
@@ -1,0 +1,136 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_and_storage_is_unavailable : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_trigger_store_circuit_breaker()
+        {
+            var delay = TimeSpan.FromSeconds(90); //To ensure this timeout would never be actually dispatched during this test
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(delay);
+                    options.RouteToThisEndpoint();
+
+                    return session.Send(new MyMessage(), options);
+                }).DoNotFailOnErrorMessages())
+                .WithEndpoint<ErrorSpy>()
+                .Done(c => c.CriticalActionCalled)
+                .Run();
+
+            Assert.False(context.Processed);
+            Assert.True(context.CriticalActionCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MovedToErrorQueue { get; set; }
+            public bool Processed { get; set; }
+            public bool CriticalActionCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
+                {
+                    var context = (Context)run.ScenarioContext;
+                    endpointConfiguration.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(ErrorSpy)));
+                    endpointConfiguration.DefineCriticalErrorAction((errorContext) =>
+                    {
+                        context.CriticalActionCalled = true;
+                        return Task.CompletedTask;
+                    });
+                    var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+
+                    var delayedDelivery = transport.NativeDelayedDelivery(new FaultyDelayedMessageStore(new SqlServerDelayedMessageStore(ConfigureEndpointMsmqTransport.GetStorageConnectionString())));
+                    delayedDelivery.NumberOfRetries = 2;
+                    delayedDelivery.TimeToTriggerDispatchCircuitBreaker = TimeSpan.FromSeconds(5);
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Processed = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        class ErrorSpy : EndpointConfigurationBuilder
+        {
+            public ErrorSpy()
+            {
+                EndpointSetup<DefaultServer>(config => config.LimitMessageProcessingConcurrencyTo(1));
+            }
+
+            class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MovedToErrorQueue = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        class FaultyDelayedMessageStore : IDelayedMessageStore
+        {
+            IDelayedMessageStore impl;
+
+            public FaultyDelayedMessageStore(IDelayedMessageStore impl)
+            {
+                this.impl = impl;
+            }
+
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+                => impl.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default) => impl.Next(cancellationToken);
+
+            public Task Store(DelayedMessage entity, CancellationToken cancellationToken = default)
+            {
+                throw new Exception("Simulated");
+            }
+
+            public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default) => impl.Remove(entity, cancellationToken);
+
+            public Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default) => impl.IncrementFailureCount(timeout, cancellationToken);
+
+            public Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default) => impl.FetchNextDueTimeout(at, cancellationToken);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_customizations_should_be_applied.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_customizations_should_be_applied.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_customizations_should_be_applied : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Customizations_should_be_applied()
+        {
+            var shortDelay = TimeSpan.FromSeconds(10);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(shortDelay);
+                    options.RouteToThisEndpoint();
+
+                    //Non-default options
+                    options.UseJournalQueue(true);
+                    options.UseDeadLetterQueue(false);
+
+                    return session.Send(new MyMessage(), options);
+                }))
+                .Done(c => c.Processed)
+                .Run();
+
+            Assert.True(context.Processed);
+            Assert.True(context.UseJournalQueue);
+            Assert.False(context.UseDeadLetterQueue);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Processed { get; set; }
+            public bool UseJournalQueue { get; set; }
+            public bool UseDeadLetterQueue { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
+                {
+                    var context = (Context)run.ScenarioContext;
+                    var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+
+                    var delayedDeliverySettings = transport.NativeDelayedDelivery(new SqlServerDelayedMessageStore(ConfigureEndpointMsmqTransport.GetStorageConnectionString()));
+
+                    delayedDeliverySettings.NumberOfRetries = 2;
+                    delayedDeliverySettings.TimeToTriggerStoreCircuitBreaker = TimeSpan.FromSeconds(5);
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Processed = true;
+                    var nativeMessage = context.Extensions.Get<System.Messaging.Message>();
+
+                    testContext.UseDeadLetterQueue = nativeMessage.UseDeadLetterQueue;
+                    testContext.UseJournalQueue = nativeMessage.UseJournalQueue;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_properties_should_be_cleaned_up.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_properties_should_be_cleaned_up.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_properties_should_be_cleaned_up : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Properties_should_be_removed_from_headers()
+        {
+            var shortDelay = TimeSpan.FromSeconds(10);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(shortDelay);
+                    options.RouteToThisEndpoint();
+
+                    return session.Send(new MyMessage(), options);
+                }))
+                .Done(c => c.Processed)
+                .Run();
+
+            Assert.True(context.Processed);
+            Assert.True(context.Headers.All(x => !x.Key.StartsWith("NServiceBus.Timeouts.Properties.")));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Processed { get; set; }
+            public IReadOnlyDictionary<string, string> Headers { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
+                {
+                    var context = (Context)run.ScenarioContext;
+                    var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+
+                    var delayedDeliverySettings = transport.NativeDelayedDelivery(new SqlServerDelayedMessageStore(ConfigureEndpointMsmqTransport.GetStorageConnectionString()));
+
+                    delayedDeliverySettings.NumberOfRetries = 2;
+                    delayedDeliverySettings.TimeToTriggerStoreCircuitBreaker = TimeSpan.FromSeconds(5);
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Headers = context.MessageHeaders;
+                    testContext.Processed = true;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_that_cant_be_stored.cs
@@ -1,0 +1,130 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_that_cant_be_stored : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_forward_to_error_queue()
+        {
+            var delay = TimeSpan.FromSeconds(5); // High value needed as most transports have multi second delay latency by default
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(delay);
+                    options.RouteToThisEndpoint();
+
+                    return session.Send(new MyMessage(), options);
+                }).DoNotFailOnErrorMessages())
+                .WithEndpoint<ErrorSpy>()
+                .Done(c => c.MovedToErrorQueue)
+                .Run();
+
+            Assert.False(context.Processed);
+            Assert.True(context.MovedToErrorQueue);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MovedToErrorQueue { get; set; }
+            public bool Processed { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(endpointConfiguration =>
+                {
+                    endpointConfiguration.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(ErrorSpy)));
+                    var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+
+                    var delayedDeliverySettings = transport.NativeDelayedDelivery(new FaultyDelayedMessageStore(new SqlServerDelayedMessageStore(ConfigureEndpointMsmqTransport.GetStorageConnectionString())));
+
+                    delayedDeliverySettings.NumberOfRetries = 2;
+                    delayedDeliverySettings.TimeToTriggerStoreCircuitBreaker = TimeSpan.FromSeconds(5);
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Processed = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        class ErrorSpy : EndpointConfigurationBuilder
+        {
+            public ErrorSpy()
+            {
+                EndpointSetup<DefaultServer>(config => config.LimitMessageProcessingConcurrencyTo(1));
+            }
+
+            class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MovedToErrorQueue = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        class FaultyDelayedMessageStore : IDelayedMessageStore
+        {
+            IDelayedMessageStore impl;
+
+            public FaultyDelayedMessageStore(IDelayedMessageStore impl)
+            {
+                this.impl = impl;
+            }
+
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+                => impl.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default) => impl.Next(cancellationToken);
+
+            public Task Store(DelayedMessage entity, CancellationToken cancellationToken = default)
+            {
+                throw new Exception("Simulated");
+            }
+
+            public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default) => impl.Remove(entity, cancellationToken);
+
+            public Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default) => impl.IncrementFailureCount(timeout, cancellationToken);
+
+            public Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default) => impl.FetchNextDueTimeout(at, cancellationToken);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_while_poller_sleeps : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_forward_to_error_queue()
+        {
+            var longDelay = TimeSpan.FromSeconds(120); //Too long for the test to pass
+            var shortDelay = TimeSpan.FromSeconds(5);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(longDelay);
+                    options.RouteToThisEndpoint();
+
+                    return session.Send(new MyMessage(), options);
+                }).When(c => c.LongDelayFetched && c.LongTimeoutStored, session =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(shortDelay);
+                    options.RouteToThisEndpoint();
+
+                    return session.Send(new MyMessage(), options);
+
+                }))
+                .Done(c => c.Processed)
+                .Run();
+
+            Assert.True(context.Processed);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Processed { get; set; }
+            public bool LongDelayFetched { get; set; }
+            public bool LongTimeoutStored { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
+                {
+                    var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+                    var delayedDeliverySettings = transport.NativeDelayedDelivery(new TestDelayedMessageStore(new SqlServerDelayedMessageStore(ConfigureEndpointMsmqTransport.GetStorageConnectionString()), (Context)run.ScenarioContext));
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Processed = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        class TestDelayedMessageStore : IDelayedMessageStore
+        {
+            readonly IDelayedMessageStore impl;
+            readonly Context context;
+
+            public TestDelayedMessageStore(IDelayedMessageStore impl, Context context)
+            {
+                this.impl = impl;
+                this.context = context;
+            }
+
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+                => impl.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public async Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
+            {
+                var next = await impl.Next(cancellationToken).ConfigureAwait(false);
+                context.LongDelayFetched = true;
+                return next;
+            }
+
+            public async Task Store(DelayedMessage entity, CancellationToken cancellationToken = default)
+            {
+                await impl.Store(entity, cancellationToken).ConfigureAwait(false);
+                context.LongTimeoutStored = true;
+            }
+
+            public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default) => impl.Remove(entity, cancellationToken);
+
+            public Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default) => impl.IncrementFailureCount(timeout, cancellationToken);
+
+            public Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default) => impl.FetchNextDueTimeout(at, cancellationToken);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,15 +1,50 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Transport.Msmq.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace NServiceBus
 {
+    public delegate System.Threading.Tasks.Task<System.Data.SqlClient.SqlConnection> CreateSqlConnection(System.Threading.CancellationToken cancellationToken = null);
+    public class static DateTimeOffsetHelper
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(string wireFormattedString) { }
+        public static string ToWireFormattedString(System.DateTimeOffset dateTime) { }
+    }
     public class static DeadLetterQueueOptionExtensions
     {
         public static void UseDeadLetterQueue(this NServiceBus.Extensibility.ExtendableOptions options, bool enable = True) { }
     }
+    public class DelayedDeliverySettings
+    {
+        public DelayedDeliverySettings() { }
+        public NServiceBus.IDelayedMessageStore DelayedMessageStore { get; }
+        public int MaximumRecoveryFailuresPerSecond { get; set; }
+        public int NumberOfRetries { get; set; }
+        public System.TimeSpan TimeToTriggerDispatchCircuitBreaker { get; set; }
+        public System.TimeSpan TimeToTriggerFetchCircuitBreaker { get; set; }
+        public System.TimeSpan TimeToTriggerStoreCircuitBreaker { get; set; }
+    }
+    public class DelayedMessage
+    {
+        public DelayedMessage() { }
+        public byte[] Body { get; set; }
+        public string Destination { get; set; }
+        public byte[] Headers { get; set; }
+        public string MessageId { get; set; }
+        public int NumberOfRetries { get; set; }
+        public System.DateTime Time { get; set; }
+    }
     public class static EndpointInstanceExtensions
     {
         public static NServiceBus.Routing.EndpointInstance AtMachine(this NServiceBus.Routing.EndpointInstance instance, string machineName) { }
+    }
+    public interface IDelayedMessageStore
+    {
+        System.Threading.Tasks.Task<NServiceBus.DelayedMessage> FetchNextDueTimeout(System.DateTimeOffset at, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<bool> IncrementFailureCount(NServiceBus.DelayedMessage entity, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task Initialize(string endpointName, NServiceBus.TransportTransactionMode transactionMode, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<System.Nullable<System.DateTimeOffset>> Next(System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<bool> Remove(NServiceBus.DelayedMessage entity, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task Store(NServiceBus.DelayedMessage entity, System.Threading.CancellationToken cancellationToken = null);
     }
     public class InstanceMappingFileSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
@@ -33,6 +68,7 @@ namespace NServiceBus
         public static void EnableJournaling(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static void IgnoreIncomingTimeToBeReceivedHeaders(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
         public static NServiceBus.InstanceMappingFileSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
+        public static NServiceBus.DelayedDeliverySettings NativeDelayedDelivery(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, NServiceBus.IDelayedMessageStore delayedMessageStore) { }
         public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
         public static void TimeToReachQueue(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, System.TimeSpan timeToReachQueue) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
@@ -50,6 +86,17 @@ namespace NServiceBus
         public override string ExampleConnectionStringForErrorMessage { get; }
         public override bool RequiresConnectionString { get; }
         public override NServiceBus.Transport.TransportInfrastructure Initialize(NServiceBus.Settings.SettingsHolder settings, string connectionString) { }
+    }
+    public class SqlServerDelayedMessageStore : NServiceBus.IDelayedMessageStore
+    {
+        public SqlServerDelayedMessageStore(string connectionString, string schema = null, string tableName = null) { }
+        public SqlServerDelayedMessageStore(NServiceBus.CreateSqlConnection connectionFactory, string schema = null, string tableName = null) { }
+        public System.Threading.Tasks.Task<NServiceBus.DelayedMessage> FetchNextDueTimeout(System.DateTimeOffset at, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<bool> IncrementFailureCount(NServiceBus.DelayedMessage timeout, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task Initialize(string queueName, NServiceBus.TransportTransactionMode transactionMode, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<System.Nullable<System.DateTimeOffset>> Next(System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<bool> Remove(NServiceBus.DelayedMessage timeout, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task Store(NServiceBus.DelayedMessage timeout, System.Threading.CancellationToken cancellationToken = null) { }
     }
 }
 namespace NServiceBus.Transport.Msmq

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqMessageDispatcherTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqMessageDispatcherTests.cs
@@ -72,7 +72,7 @@
                 MsmqHelpers.DeleteQueue(path);
                 MsmqHelpers.CreateQueue(path);
 
-                var messageSender = new MsmqMessageDispatcher(settings);
+                var messageSender = new MsmqMessageDispatcher(settings, null);
 
                 var bytes = new byte[]
                 {

--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.Msmq/CompositePump.cs
+++ b/src/NServiceBus.Transport.Msmq/CompositePump.cs
@@ -1,0 +1,42 @@
+namespace NServiceBus.Transport.Msmq
+{
+    using System;
+    using System.Threading.Tasks;
+
+    class CompositePump : IPushMessages
+    {
+        readonly IPushMessages mainPump;
+        readonly IPushMessages delayedDeliveryPump;
+
+        public CompositePump(IPushMessages mainPump, IPushMessages delayedDeliveryPump)
+        {
+            this.mainPump = mainPump;
+            this.delayedDeliveryPump = delayedDeliveryPump;
+        }
+
+        public async Task Init(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, CriticalError criticalError, PushSettings settings)
+        {
+            await mainPump.Init(onMessage, onError, criticalError, settings).ConfigureAwait(false);
+            if (delayedDeliveryPump != null)
+            {
+                await delayedDeliveryPump.Init(onMessage, onError, criticalError, settings).ConfigureAwait(false);
+            }
+        }
+
+        public void Start(PushRuntimeSettings limitations)
+        {
+            mainPump.Start(limitations);
+            //Delayed delivery pump always uses default concurrency settings
+            delayedDeliveryPump?.Start(PushRuntimeSettings.Default);
+        }
+
+        public async Task Stop()
+        {
+            await mainPump.Stop().ConfigureAwait(false);
+            if (delayedDeliveryPump != null)
+            {
+                await delayedDeliveryPump.Stop().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DateTimeOffsetExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/DateTimeOffsetExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus
+{
+    using System;
+
+    static class DateTimeOffsetExtensions
+    {
+        public static int Microseconds(this DateTimeOffset self)
+        {
+            // This appears to be a false positive for IDE0047
+#pragma warning disable IDE0047 // Remove unnecessary parentheses
+            return (int)Math.Floor((self.Ticks % TimeSpan.TicksPerMillisecond) / (double)ticksPerMicrosecond);
+#pragma warning restore IDE0047 // Remove unnecessary parentheses
+        }
+
+        public static DateTimeOffset AddMicroseconds(this DateTimeOffset self, int microseconds)
+        {
+            return self.AddTicks(microseconds * ticksPerMicrosecond);
+        }
+
+        const int ticksPerMicrosecond = (int)TimeSpan.TicksPerMillisecond / 1000;
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DateTimeOffsetHelper.cs
+++ b/src/NServiceBus.Transport.Msmq/DateTimeOffsetHelper.cs
@@ -1,0 +1,123 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Globalization;
+    using NServiceBus.Transport.Msmq;
+
+    /// <summary>
+    /// Common date time extensions.
+    /// </summary>
+    public static class DateTimeOffsetHelper
+    {
+        /// <summary>
+        /// Converts the <see cref="DateTimeOffset" /> to a <see cref="string" /> suitable for transport over the wire.
+        /// </summary>
+        public static string ToWireFormattedString(DateTimeOffset dateTime)
+        {
+            return dateTime.ToUniversalTime().ToString(format, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts a wire formatted <see cref="string" /> from <see cref="ToWireFormattedString" /> to a UTC
+        /// <see cref="DateTimeOffset" />.
+        /// </summary>
+        public static DateTimeOffset ToDateTimeOffset(string wireFormattedString)
+        {
+            Guard.AgainstNullAndEmpty(nameof(wireFormattedString), wireFormattedString);
+
+            if (wireFormattedString.Length != format.Length)
+            {
+                throw new FormatException(errorMessage);
+            }
+
+            var year = 0;
+            var month = 0;
+            var day = 0;
+            var hour = 0;
+            var minute = 0;
+            var second = 0;
+            var microSecond = 0;
+
+            for (var i = 0; i < format.Length; i++)
+            {
+                var digit = wireFormattedString[i];
+
+                switch (format[i])
+                {
+                    case 'y':
+                        if (digit < '0' || digit > '9')
+                        {
+                            throw new FormatException(errorMessage);
+                        }
+
+                        year = (year * 10) + (digit - '0');
+                        break;
+
+                    case 'M':
+                        if (digit < '0' || digit > '9')
+                        {
+                            throw new FormatException(errorMessage);
+                        }
+
+                        month = (month * 10) + (digit - '0');
+                        break;
+
+                    case 'd':
+                        if (digit < '0' || digit > '9')
+                        {
+                            throw new FormatException(errorMessage);
+                        }
+
+                        day = (day * 10) + (digit - '0');
+                        break;
+
+                    case 'H':
+                        if (digit < '0' || digit > '9')
+                        {
+                            throw new FormatException(errorMessage);
+                        }
+
+                        hour = (hour * 10) + (digit - '0');
+                        break;
+
+                    case 'm':
+                        if (digit < '0' || digit > '9')
+                        {
+                            throw new FormatException(errorMessage);
+                        }
+
+                        minute = (minute * 10) + (digit - '0');
+                        break;
+
+                    case 's':
+                        if (digit < '0' || digit > '9')
+                        {
+                            throw new FormatException(errorMessage);
+                        }
+
+                        second = (second * 10) + (digit - '0');
+                        break;
+
+                    case 'f':
+                        if (digit < '0' || digit > '9')
+                        {
+                            throw new FormatException(errorMessage);
+                        }
+
+                        microSecond = (microSecond * 10) + (digit - '0');
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            var timestamp = new DateTimeOffset(year, month, day, hour, minute, second, TimeSpan.Zero);
+            timestamp = timestamp.AddMicroseconds(microSecond);
+            return timestamp;
+        }
+
+        const string format = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+        const string errorMessage = "String was not recognized as a valid DateTime.";
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/DelayedDeliveryPump.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/DelayedDeliveryPump.cs
@@ -1,0 +1,161 @@
+namespace NServiceBus.Transport.Msmq.DelayedDelivery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using Logging;
+    using Extensibility;
+    using Routing;
+
+    class DelayedDeliveryPump : IPushMessages
+    {
+        public DelayedDeliveryPump(MsmqMessageDispatcher dispatcher,
+                                   DueDelayedMessagePoller poller,
+                                   IDelayedMessageStore storage,
+                                   MessagePump messagePump,
+                                   string timeoutsQueue,
+                                   string errorQueue,
+                                   int numberOfRetries,
+                                   TimeSpan timeToWaitForStoreCircuitBreaker,
+                                   Dictionary<string, string> faultMetadata)
+        {
+            this.dispatcher = dispatcher;
+            this.poller = poller;
+            this.storage = storage;
+            this.numberOfRetries = numberOfRetries;
+            this.timeToWaitForStoreCircuitBreaker = timeToWaitForStoreCircuitBreaker;
+            this.faultMetadata = faultMetadata;
+            pump = messagePump;
+            this.errorQueue = errorQueue;
+            this.timeoutsQueue = timeoutsQueue;
+        }
+
+        public Task Init(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, CriticalError criticalError, PushSettings settings)
+        {
+            txOption = settings.RequiredTransactionMode == TransportTransactionMode.TransactionScope
+                ? TransactionScopeOption.Required
+                : TransactionScopeOption.RequiresNew;
+
+            storeCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("DelayedDeliveryStore", timeToWaitForStoreCircuitBreaker, ex => criticalError.Raise("Failed to store delayed message", ex));
+            poller.Init(criticalError, settings);
+
+            // Make sure to use the timeouts input queue
+            settings = new PushSettings(timeoutsQueue, settings.ErrorQueue, settings.PurgeOnStartup, settings.RequiredTransactionMode);
+
+            return pump.Init(TimeoutReceived, OnError, criticalError, settings);
+        }
+
+        public void Start(PushRuntimeSettings limitations)
+        {
+            pump.Start(limitations);
+            poller.Start();
+        }
+
+        public async Task Stop()
+        {
+            await pump.Stop().ConfigureAwait(false);
+            await poller.Stop().ConfigureAwait(false);
+        }
+
+        async Task TimeoutReceived(MessageContext context)
+        {
+            if (!context.Headers.TryGetValue(MsmqUtilities.PropertyHeaderPrefix + MsmqMessageDispatcher.TimeoutDestination, out var destination))
+            {
+                throw new Exception("This message does not represent a timeout");
+            }
+
+            if (!context.Headers.TryGetValue(MsmqUtilities.PropertyHeaderPrefix + MsmqMessageDispatcher.TimeoutAt, out var atString))
+            {
+                throw new Exception("This message does not represent a timeout");
+            }
+
+            var id = context.MessageId; //Use message ID as a key in the delayed delivery table
+            var at = DateTimeOffsetHelper.ToDateTimeOffset(atString);
+
+            var message = context.Extensions.Get<System.Messaging.Message>();
+
+            var diff = DateTime.UtcNow - at;
+
+            if (diff.Ticks > 0) // Due
+            {
+                dispatcher.DispatchDelayedMessage(id, message.Extension, context.Body, destination, context.TransportTransaction, new ContextBag());
+            }
+            else
+            {
+                var timeout = new DelayedMessage
+                {
+                    Destination = destination,
+                    MessageId = id,
+                    Body = context.Body,
+                    Time = at.UtcDateTime,
+                    Headers = message.Extension
+                };
+
+                try
+                {
+                    using (var tx = new TransactionScope(txOption, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+                    {
+                        await storage.Store(timeout).ConfigureAwait(false);
+                        tx.Complete();
+                    }
+
+                    storeCircuitBreaker.Success();
+                }
+                catch (OperationCanceledException)
+                {
+                    //Shutting down
+                    return;
+                }
+                catch (Exception e)
+                {
+                    await storeCircuitBreaker.Failure(e).ConfigureAwait(false);
+                    throw new Exception("Error while storing delayed message", e);
+                }
+
+                poller.Signal(timeout.Time);
+            }
+        }
+
+        async Task<ErrorHandleResult> OnError(ErrorContext errorContext)
+        {
+            Log.Error($"OnError {errorContext.Message.MessageId}", errorContext.Exception);
+
+            if (errorContext.ImmediateProcessingFailures < numberOfRetries)
+            {
+                return ErrorHandleResult.RetryRequired;
+            }
+
+            var message = errorContext.Message;
+
+            ExceptionHeaderHelper.SetExceptionHeaders(message.Headers, errorContext.Exception);
+
+            foreach (var pair in faultMetadata)
+            {
+                message.Headers[pair.Key] = pair.Value;
+            }
+
+            var outgoingMessage = new OutgoingMessage(message.MessageId, message.Headers, message.Body);
+            var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(errorQueue));
+            await dispatcher.Dispatch(new TransportOperations(transportOperation), errorContext.TransportTransaction, new ContextBag()).ConfigureAwait(false);
+
+            return ErrorHandleResult.Handled;
+        }
+
+        readonly MsmqMessageDispatcher dispatcher;
+        readonly DueDelayedMessagePoller poller;
+        readonly IDelayedMessageStore storage;
+        readonly int numberOfRetries;
+        readonly TimeSpan timeToWaitForStoreCircuitBreaker;
+        readonly MessagePump pump;
+        readonly Dictionary<string, string> faultMetadata;
+        readonly string errorQueue;
+        readonly string timeoutsQueue;
+        readonly TransactionOptions transactionOptions = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+
+        RepeatedFailuresOverTimeCircuitBreaker storeCircuitBreaker;
+        TransactionScopeOption txOption;
+
+        static readonly ILog Log = LogManager.GetLogger<DelayedDeliveryPump>();
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/DelayedDeliverySettings.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/DelayedDeliverySettings.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using Transport.Msmq;
+
+    /// <summary>
+    /// Configures delayed delivery support.
+    /// </summary>
+    public class DelayedDeliverySettings
+    {
+        int numberOfRetries;
+        TimeSpan timeToTriggerStoreCircuitBreaker = TimeSpan.FromSeconds(30);
+        TimeSpan timeToTriggerFetchCircuitBreaker = TimeSpan.FromSeconds(30);
+        TimeSpan timeToTriggerDispatchCircuitBreaker = TimeSpan.FromSeconds(30);
+        int maximumRecoveryFailuresPerSecond = 1;
+
+        /// <summary>
+        /// The store to keep delayed messages.
+        /// </summary>
+        public IDelayedMessageStore DelayedMessageStore { get; internal set; }
+
+        /// <summary>
+        /// Number of retries when trying to forward due delayed messages.
+        /// </summary>
+        public int NumberOfRetries
+        {
+            get => numberOfRetries;
+            set
+            {
+                Guard.AgainstNegativeAndZero("value", value);
+                numberOfRetries = value;
+            }
+        }
+
+        /// <summary>
+        /// Time to wait before triggering the circuit breaker that monitors the storing of delayed messages in the database. Defaults to 30 seconds.
+        /// </summary>
+        public TimeSpan TimeToTriggerStoreCircuitBreaker
+        {
+            get => timeToTriggerStoreCircuitBreaker;
+            set
+            {
+                Guard.AgainstNegativeAndZero("value", value);
+                timeToTriggerStoreCircuitBreaker = value;
+            }
+        }
+
+        /// <summary>
+        /// Time to wait before triggering the circuit breaker that monitors the fetching of due delayed messages from the database. Defaults to 30 seconds.
+        /// </summary>
+        public TimeSpan TimeToTriggerFetchCircuitBreaker
+        {
+            get => timeToTriggerFetchCircuitBreaker;
+            set
+            {
+                Guard.AgainstNegativeAndZero("value", value);
+                timeToTriggerFetchCircuitBreaker = value;
+            }
+        }
+
+        /// <summary>
+        /// Time to wait before triggering the circuit breaker that monitors the dispatching of due delayed messages to the destination. Defaults to 30 seconds.
+        /// </summary>
+        public TimeSpan TimeToTriggerDispatchCircuitBreaker
+        {
+            get => timeToTriggerDispatchCircuitBreaker;
+            set
+            {
+                Guard.AgainstNegativeAndZero("value", value);
+                timeToTriggerDispatchCircuitBreaker = value;
+            }
+        }
+
+        /// <summary>
+        /// Maximum number of recovery failures per second that triggers the recovery circuit breaker. Recovery attempts are attempts to increment the failure
+        /// counter after a failed dispatch and forwarding messages to the error queue. Defaults to 1/s.
+        /// </summary>
+        public int MaximumRecoveryFailuresPerSecond
+        {
+            get => maximumRecoveryFailuresPerSecond;
+            set
+            {
+                Guard.AgainstNegativeAndZero("value", value);
+                maximumRecoveryFailuresPerSecond = value;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/DelayedMessage.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/DelayedMessage.cs
@@ -1,0 +1,41 @@
+
+namespace NServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// Represents a delayed message.
+    /// </summary>
+    public class DelayedMessage
+    {
+        /// <summary>
+        /// Date and time the message is due.
+        /// </summary>
+        public DateTime Time { get; set; }
+
+        /// <summary>
+        /// Native message ID
+        /// </summary>
+        public string MessageId { get; set; }
+
+        /// <summary>
+        /// The body of the message.
+        /// </summary>
+        public byte[] Body { get; set; }
+
+        /// <summary>
+        /// The serialized headers of the message
+        /// </summary>
+        public byte[] Headers { get; set; }
+
+        /// <summary>
+        /// The address of the destination queue
+        /// </summary>
+        public string Destination { get; set; }
+
+        /// <summary>
+        /// The number of attempt already made to forward the message to its destination.
+        /// </summary>
+        public int NumberOfRetries { get; set; }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/DueDelayedMessagePoller.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/DueDelayedMessagePoller.cs
@@ -1,0 +1,359 @@
+namespace NServiceBus.Transport.Msmq.DelayedDelivery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Channels;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using Logging;
+    using Extensibility;
+    using Routing;
+    using Unicast.Queuing;
+
+    class DueDelayedMessagePoller
+    {
+        public DueDelayedMessagePoller(
+            MsmqMessageDispatcher dispatcher,
+            IDelayedMessageStore delayedMessageStore,
+            int numberOfRetries,
+            string timeoutsErrorQueue,
+            Dictionary<string, string> faultMetadata,
+            TimeSpan timeToTriggerFetchCircuitBreaker,
+            TimeSpan timeToTriggerDispatchCircuitBreaker,
+            int maximumRecoveryFailuresPerSecond
+        )
+        {
+            this.delayedMessageStore = delayedMessageStore;
+            errorQueue = timeoutsErrorQueue;
+            this.faultMetadata = faultMetadata;
+            this.timeToTriggerFetchCircuitBreaker = timeToTriggerFetchCircuitBreaker;
+            this.timeToTriggerDispatchCircuitBreaker = timeToTriggerDispatchCircuitBreaker;
+            this.maximumRecoveryFailuresPerSecond = maximumRecoveryFailuresPerSecond;
+            this.numberOfRetries = numberOfRetries;
+            this.dispatcher = dispatcher;
+
+            signalQueue = Channel.CreateBounded<bool>(1);
+            taskQueue = Channel.CreateBounded<Task>(2);
+        }
+
+        public void Init(CriticalError criticalError, PushSettings pushSettings)
+        {
+            txOption = pushSettings.RequiredTransactionMode == TransportTransactionMode.TransactionScope
+                ? TransactionScopeOption.Required
+                : TransactionScopeOption.RequiresNew;
+
+            fetchCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("MsmqDelayedMessageFetch", timeToTriggerFetchCircuitBreaker,
+                ex => criticalError.Raise("Failed to fetch due delayed messages from the storage", ex));
+
+            dispatchCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("MsmqDelayedMessageDispatch", timeToTriggerDispatchCircuitBreaker,
+                ex => criticalError.Raise("Failed to dispatch delayed messages to destination", ex));
+
+            failureHandlingCircuitBreaker = new FailureRateCircuitBreaker("MsmqDelayedMessageFailureHandling", maximumRecoveryFailuresPerSecond,
+                ex => criticalError.Raise("Failed to execute error handling for delayed message forwarding", ex));
+        }
+
+        public void Start()
+        {
+            tokenSource = new CancellationTokenSource();
+            loopTask = Task.Run(() => Loop(tokenSource.Token));
+            completionTask = Task.Run(() => AwaitHandleTasks());
+        }
+
+        public async Task Stop()
+        {
+            tokenSource.Cancel();
+            await loopTask.ConfigureAwait(false);
+            await completionTask.ConfigureAwait(false);
+        }
+
+        public void Signal(DateTimeOffset timeoutTime)
+        {
+            //If the next timeout is within a minute from now, trigger the poller
+            if (DateTimeOffset.UtcNow.Add(MaxSleepDuration) > timeoutTime)
+            {
+                //If there is something already in the queue we are fine.
+                signalQueue.Writer.TryWrite(true);
+            }
+        }
+
+        /// <summary>
+        /// This method does not accept a cancellation token because it needs to finish all the tasks that have been started even if cancellation is under way.
+        /// </summary>
+        async Task AwaitHandleTasks()
+        {
+            while (await taskQueue.Reader.WaitToReadAsync().ConfigureAwait(false)) //if this returns false the channel is completed
+            {
+                while (taskQueue.Reader.TryRead(out var task))
+                {
+                    try
+                    {
+                        await task.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        Log.Debug("A shutdown was triggered and Poll task has been cancelled.");
+                    }
+                    catch (Exception e)
+                    {
+                        failureHandlingCircuitBreaker.Failure(e);
+                    }
+                }
+            }
+        }
+
+        async Task Loop(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+
+                        //We create a TaskCompletionSource source here and pass it to spawned Poll task. Once the Poll task is done with fetching
+                        //the next due timeout, we continue with the loop. This allows us to run the Poll tasks in an overlapping way so that at any time there is
+                        //one Poll task fetching and one dispatching.
+
+                        var completionSource = new TaskCompletionSource<DateTimeOffset?>();
+                        var handleTask = Poll(completionSource, cancellationToken);
+                        await taskQueue.Writer.WriteAsync(handleTask, cancellationToken).ConfigureAwait(false);
+                        var nextPoll = await completionSource.Task.ConfigureAwait(false);
+
+                        if (nextPoll.HasValue)
+                        {
+                            //We wait either for a signal that a new delayed message has been stored or until next timeout should be due
+                            //After waiting we cancel the token so that the task waiting for the signal is cancelled and does not "eat" the next
+                            //signal when it is raised in the next iteration of this loop
+                            using (var waitCancelled = new CancellationTokenSource())
+                            {
+                                var combinedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, waitCancelled.Token);
+
+                                var waitTask = WaitIfNeeded(nextPoll.Value, combinedSource.Token);
+                                var signalTask = WaitForSignal(combinedSource.Token);
+
+                                await Task.WhenAny(waitTask, signalTask).ConfigureAwait(false);
+                                waitCancelled.Cancel();
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        Log.Debug("A shutdown was triggered, canceling the Loop operation.");
+                        break;
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error("Failed to poll and dispatch due timeouts from storage.", e);
+                        //Poll and HandleDueDelayedMessage have their own exception handling logic so any exception here is likely going to be related to the transaction itself
+                        await fetchCircuitBreaker.Failure(e).ConfigureAwait(false);
+                    }
+                }
+            }
+            finally
+            {
+                //No matter what we need to complete the writer so that we can stop gracefully
+                taskQueue.Writer.Complete();
+            }
+        }
+
+        async Task WaitForSignal(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await signalQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                Log.Debug("No new delayed messages have been stored while waiting for the next due delayed message.");
+            }
+        }
+
+        Task WaitIfNeeded(DateTimeOffset nextPoll, CancellationToken cancellationToken)
+        {
+            var waitTime = nextPoll - DateTimeOffset.UtcNow;
+            if (waitTime > TimeSpan.Zero)
+            {
+                return Task.Delay(waitTime, cancellationToken);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        async Task Poll(TaskCompletionSource<DateTimeOffset?> result, CancellationToken cancellationToken)
+        {
+            DelayedMessage timeout = null;
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            try
+            {
+                using (var tx = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    timeout = await delayedMessageStore.FetchNextDueTimeout(now, cancellationToken).ConfigureAwait(false);
+                    fetchCircuitBreaker.Success();
+
+                    if (timeout != null)
+                    {
+                        result.SetResult(null);
+                        HandleDueDelayedMessage(timeout);
+
+                        var success = await delayedMessageStore.Remove(timeout, cancellationToken).ConfigureAwait(false);
+                        if (!success)
+                        {
+                            Log.WarnFormat("Potential more-than-once dispatch as delayed message already removed from storage.");
+                        }
+                    }
+                    else
+                    {
+                        using (new TransactionScope(TransactionScopeOption.RequiresNew, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+                        {
+                            var nextDueTimeout = await delayedMessageStore.Next(cancellationToken).ConfigureAwait(false);
+                            if (nextDueTimeout.HasValue)
+                            {
+                                result.SetResult(nextDueTimeout);
+                            }
+                            else
+                            {
+                                //If no timeouts, wait a while
+                                result.SetResult(now.Add(MaxSleepDuration));
+                            }
+                        }
+                    }
+                    tx.Complete();
+                }
+            }
+            catch (QueueNotFoundException exception)
+            {
+                if (timeout != null)
+                {
+                    await TrySendDelayedMessageToErrorQueue(timeout, exception, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                //Shutting down. Bubble up the exception. Will be awaited by AwaitHandleTasks method that catches OperationCanceledExceptions
+                throw;
+            }
+            catch (Exception exception)
+            {
+                Log.Error("Failure during timeout polling.", exception);
+                if (timeout != null)
+                {
+                    await dispatchCircuitBreaker.Failure(exception).ConfigureAwait(false);
+                    using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+                    {
+                        await delayedMessageStore.IncrementFailureCount(timeout, cancellationToken).ConfigureAwait(false);
+                        scope.Complete();
+                    }
+
+                    if (timeout.NumberOfRetries > numberOfRetries)
+                    {
+                        await TrySendDelayedMessageToErrorQueue(timeout, exception, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    await fetchCircuitBreaker.Failure(exception).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                //In case we failed before SetResult
+                result.TrySetResult(null);
+            }
+        }
+
+        void HandleDueDelayedMessage(DelayedMessage timeout)
+        {
+            TimeSpan diff = DateTimeOffset.UtcNow - new DateTimeOffset(timeout.Time, TimeSpan.Zero);
+
+            Log.DebugFormat("Timeout {0} over due for {1}", timeout.MessageId, diff);
+
+            using (var tx = new TransactionScope(txOption, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var transportTransaction = new TransportTransaction();
+                transportTransaction.Set(Transaction.Current);
+                dispatcher.DispatchDelayedMessage(
+                    timeout.MessageId,
+                    timeout.Headers,
+                    timeout.Body,
+                    timeout.Destination,
+                    transportTransaction,
+                    new ContextBag()
+                );
+
+                tx.Complete();
+            }
+
+            dispatchCircuitBreaker.Success();
+        }
+
+        async Task TrySendDelayedMessageToErrorQueue(DelayedMessage timeout, Exception exception, CancellationToken cancellationToken)
+        {
+            try
+            {
+                bool success = await delayedMessageStore.Remove(timeout, cancellationToken).ConfigureAwait(false);
+
+                if (!success)
+                {
+                    // Already dispatched
+                    return;
+                }
+
+                Dictionary<string, string> headersAndProperties = MsmqUtilities.DeserializeMessageHeaders(timeout.Headers);
+
+                ExceptionHeaderHelper.SetExceptionHeaders(headersAndProperties, exception);
+
+                foreach (KeyValuePair<string, string> pair in faultMetadata)
+                {
+                    headersAndProperties[pair.Key] = pair.Value;
+                }
+
+                Log.InfoFormat("Move {0} to error queue", timeout.MessageId);
+                using (var transportTx = new TransactionScope(txOption, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    var transportTransaction = new TransportTransaction();
+                    transportTransaction.Set(Transaction.Current);
+
+                    var outgoingMessage = new OutgoingMessage(timeout.MessageId, headersAndProperties, timeout.Body);
+                    var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(errorQueue));
+                    await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, new ContextBag())
+                        .ConfigureAwait(false);
+
+                    transportTx.Complete();
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                //Shutting down
+                Log.Debug("Aborted sending delayed message to error queue due to shutdown.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Failed to move delayed message {timeout.MessageId} to the error queue {errorQueue} after {timeout.NumberOfRetries} failed attempts at dispatching it to the destination", ex);
+            }
+        }
+
+        static readonly ILog Log = LogManager.GetLogger<DueDelayedMessagePoller>();
+        static readonly TimeSpan MaxSleepDuration = TimeSpan.FromMinutes(1);
+
+        readonly Dictionary<string, string> faultMetadata;
+        readonly TimeSpan timeToTriggerFetchCircuitBreaker;
+        readonly TimeSpan timeToTriggerDispatchCircuitBreaker;
+        readonly int maximumRecoveryFailuresPerSecond;
+
+        IDelayedMessageStore delayedMessageStore;
+        MsmqMessageDispatcher dispatcher;
+        string errorQueue;
+        int numberOfRetries;
+        RepeatedFailuresOverTimeCircuitBreaker fetchCircuitBreaker;
+        RepeatedFailuresOverTimeCircuitBreaker dispatchCircuitBreaker;
+        FailureRateCircuitBreaker failureHandlingCircuitBreaker;
+        Task loopTask;
+        Task completionTask;
+        Channel<bool> signalQueue;
+        Channel<Task> taskQueue;
+        CancellationTokenSource tokenSource;
+        TransactionScopeOption txOption;
+        TransactionOptions transactionOptions = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/IDelayedMessageStore.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/IDelayedMessageStore.cs
@@ -1,0 +1,57 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Represents a store for delayed messages.
+    /// </summary>
+    public interface IDelayedMessageStore
+    {
+        /// <summary>
+        /// Initializes the storage e.g. creates required database artifacts etc.
+        /// </summary>
+        /// <param name="endpointName">Name of the endpoint that hosts the delayed delivery storage.</param>
+        /// <param name="transactionMode">The transaction mode selected for the transport. The storage implementation should throw an exception if it can't support specified
+        /// transaction mode e.g. TransactionScope mode requires the storage to enlist in a distributed transaction managed by the DTC.</param>
+        /// <param name="cancellationToken">The cancellation token set if the endpoint begins to shut down while the Initialize method is executing.</param>
+        Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns the date and time set for the next delayed message to become due or null if there are no delayed messages stored.
+        /// </summary>
+        /// <returns></returns>
+        Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Stores a delayed message.
+        /// </summary>
+        /// <param name="entity">Object representing a delayed message.</param>
+        /// <param name="cancellationToken">The cancellation token for cooperative cancellation</param>
+        Task Store(DelayedMessage entity, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a due delayed message that has been dispatched to its destination from the store.
+        /// </summary>
+        /// <param name="entity">Object representing a delayed message previously returned by FetchNextDueTimeout.</param>
+        /// <param name="cancellationToken">The cancellation token for cooperative cancellation</param>
+        /// <returns>True if the removal succeeded. False if there was nothing to remove because the delayed message was already gone.</returns>
+        Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Increments the counter of failures for a given due delayed message.
+        /// </summary>
+        /// <param name="entity">Object representing a delayed message previously returned by FetchNextDueTimeout.</param>
+        /// <param name="cancellationToken">The cancellation token for cooperative cancellation</param>
+        /// <returns>True if the increment succeeded. False if the delayed message was already gone.</returns>
+        Task<bool> IncrementFailureCount(DelayedMessage entity, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves the oldest due delayed message from the store or returns null if there is no due delayed messages.
+        /// </summary>
+        /// <param name="at">The point in time to which to compare the due date of the messages.</param>
+        /// <param name="cancellationToken">The cancellation token for cooperative cancellation</param>
+        Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/SqlConstants.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/SqlConstants.cs
@@ -1,0 +1,41 @@
+namespace NServiceBus.Transport.Msmq.DelayedDelivery.Sql
+{
+    class SqlConstants
+    {
+        public const string SqlInsert = "INSERT INTO {0} (Id, Destination, Time, Headers, State) VALUES (@id, @destination, @time, @headers, @state);";
+        public const string SqlFetch = "SELECT TOP 1 Id, Destination, Time, Headers, State, RetryCount FROM {0} WITH (READPAST, UPDLOCK, ROWLOCK) WHERE Time < @time ORDER BY Time";
+        public const string SqlDelete = "DELETE {0} WHERE Id = @id";
+        public const string SqlUpdate = "UPDATE {0} SET RetryCount = RetryCount + 1 WHERE Id = @id";
+        public const string SqlGetNext = "SELECT TOP 1 Time FROM {0} ORDER BY Time";
+        public const string SqlCreateTable = @"
+if not exists (
+    select * from sys.objects
+    where
+        object_id = object_id('{0}')
+        and type in ('U')
+)
+begin
+    create table {0} (
+ 	    Id nvarchar(250) not null primary key,
+        Destination nvarchar(200),
+        State varbinary(max),
+        Time datetime,
+        Headers varbinary(max) not null,
+        RetryCount INT NOT NULL default(0)
+        )
+end
+
+if not exists
+(
+    select *
+    from sys.indexes
+    where
+        name = 'Index_Time' and
+        object_id = object_id('{0}')
+)
+begin
+    create index Index_Time on {0} (Time);
+end
+";
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/SqlNameHelper.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/SqlNameHelper.cs
@@ -1,0 +1,33 @@
+namespace NServiceBus.Transport.Msmq.DelayedDelivery.Sql
+{
+    class SqlNameHelper
+    {
+        const string Prefix = "[";
+        const string Suffix = "]";
+
+        public static string Quote(string unquotedName)
+        {
+            if (unquotedName == null)
+            {
+                return null;
+            }
+            return Prefix + unquotedName.Replace(Suffix, Suffix + Suffix) + Suffix;
+        }
+
+        public static string Unquote(string quotedString)
+        {
+            if (quotedString == null)
+            {
+                return null;
+            }
+
+            if (!quotedString.StartsWith(Prefix) || !quotedString.EndsWith(Suffix))
+            {
+                return quotedString;
+            }
+
+            return quotedString
+                .Substring(Prefix.Length, quotedString.Length - Prefix.Length - Suffix.Length).Replace(Suffix + Suffix, Suffix);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/SqlServerDelayedMessageStore.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/SqlServerDelayedMessageStore.cs
@@ -1,0 +1,160 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Transport.Msmq.DelayedDelivery.Sql;
+
+    //TODO: Either we should expect that the connection created by the factory is open of we should make it non-async
+    /// <summary>
+    /// Factory method for creating SQL Server connections.
+    /// </summary>
+    public delegate Task<SqlConnection> CreateSqlConnection(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Implementation of the delayed message store based on the SQL Server.
+    /// </summary>
+    public class SqlServerDelayedMessageStore : IDelayedMessageStore
+    {
+        string schema;
+        string tableName;
+        CreateSqlConnection createSqlConnection;
+
+        string insertCommand;
+        string removeCommand;
+        string bumpFailureCountCommand;
+        string nextCommand;
+        string fetchCommand;
+
+        /// <summary>
+        /// Creates a new instance of the SQL Server delayed message store.
+        /// </summary>
+        /// <param name="connectionString">Connection string to the SQL Server database.</param>
+        /// <param name="schema">(optional) schema to use. Defaults to dbo</param>
+        /// <param name="tableName">(optional) name of the table where delayed messages are stored. Defaults to name of the endpoint with .Delayed suffix.</param>
+        public SqlServerDelayedMessageStore(string connectionString, string schema = null, string tableName = null)
+            : this(token => Task.FromResult(new SqlConnection(connectionString)), schema, tableName)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the SQL Server delayed message store.
+        /// </summary>
+        /// <param name="connectionFactory">Factory for database connections.</param>
+        /// <param name="schema">(optional) schema to use. Defaults to dbo</param>
+        /// <param name="tableName">(optional) name of the table where delayed messages are stored. Defaults to name of the endpoint with .Delayed suffix.</param>
+        public SqlServerDelayedMessageStore(CreateSqlConnection connectionFactory, string schema = null, string tableName = null)
+        {
+            createSqlConnection = connectionFactory;
+            this.tableName = tableName;
+            this.schema = schema ?? "dbo";
+        }
+
+        /// <inheritdoc />
+        public async Task Store(DelayedMessage timeout, CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken).ConfigureAwait(false))
+            using (var cmd = new SqlCommand(insertCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+                cmd.Parameters.AddWithValue("@destination", timeout.Destination);
+                cmd.Parameters.AddWithValue("@time", timeout.Time);
+                cmd.Parameters.AddWithValue("@headers", timeout.Headers);
+                cmd.Parameters.AddWithValue("@state", timeout.Body);
+                await cn.OpenAsync(cancellationToken).ConfigureAwait(false);
+                _ = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+
+        /// <inheritdoc />
+        public async Task<bool> Remove(DelayedMessage timeout, CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken).ConfigureAwait(false))
+            using (var cmd = new SqlCommand(removeCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+                await cn.OpenAsync(cancellationToken).ConfigureAwait(false);
+                var affected = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                return affected == 1;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken).ConfigureAwait(false))
+            using (var cmd = new SqlCommand(bumpFailureCountCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+                await cn.OpenAsync(cancellationToken).ConfigureAwait(false);
+                var affected = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                return affected == 1;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task Initialize(string queueName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+        {
+            if (tableName == null)
+            {
+                tableName = $"{queueName}.timeouts";
+            }
+
+            var quotedFullName = $"{SqlNameHelper.Quote(schema)}.{SqlNameHelper.Quote(tableName)}";
+
+            var creator = new TimeoutTableCreator(createSqlConnection, quotedFullName);
+            await creator.CreateIfNecessary(cancellationToken).ConfigureAwait(false);
+
+            insertCommand = string.Format(SqlConstants.SqlInsert, quotedFullName);
+            removeCommand = string.Format(SqlConstants.SqlDelete, quotedFullName);
+            bumpFailureCountCommand = string.Format(SqlConstants.SqlUpdate, quotedFullName);
+            nextCommand = string.Format(SqlConstants.SqlGetNext, quotedFullName);
+            fetchCommand = string.Format(SqlConstants.SqlFetch, quotedFullName);
+        }
+
+        /// <inheritdoc />
+        public async Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken).ConfigureAwait(false))
+            using (var cmd = new SqlCommand(nextCommand, cn))
+            {
+                await cn.OpenAsync(cancellationToken).ConfigureAwait(false);
+                var result = (DateTime?)await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return result.HasValue ? (DateTimeOffset?)new DateTimeOffset(result.Value, TimeSpan.Zero) : null;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
+        {
+            DelayedMessage result = null;
+            using (var cn = await createSqlConnection(cancellationToken).ConfigureAwait(false))
+            using (var cmd = new SqlCommand(fetchCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@time", at.UtcDateTime);
+
+                await cn.OpenAsync(cancellationToken).ConfigureAwait(false);
+                using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow, cancellationToken).ConfigureAwait(false))
+                {
+                    if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        result = new DelayedMessage
+                        {
+                            MessageId = (string)reader[0],
+                            Destination = (string)reader[1],
+                            Time = (DateTime)reader[2],
+                            Headers = (byte[])reader[3],
+                            Body = (byte[])reader[4],
+                            NumberOfRetries = (int)reader[5]
+                        };
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/TimeoutTableCreator.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/Sql/TimeoutTableCreator.cs
@@ -1,0 +1,52 @@
+namespace NServiceBus.Transport.Msmq.DelayedDelivery.Sql
+{
+    using System.Data.SqlClient;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class TimeoutTableCreator
+    {
+        public TimeoutTableCreator(CreateSqlConnection createSqlConnection, string tableName)
+        {
+            this.tableName = tableName;
+            this.createSqlConnection = createSqlConnection;
+        }
+
+        public async Task CreateIfNecessary(CancellationToken cancellationToken = default)
+        {
+            var sql = string.Format(SqlConstants.SqlCreateTable, tableName);
+            using (var connection = await createSqlConnection(cancellationToken).ConfigureAwait(false))
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await Execute(sql, connection, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        static async Task Execute(string sql, SqlConnection connection, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using (var transaction = connection.BeginTransaction())
+                {
+                    using (var command = new SqlCommand(sql, connection, transaction))
+                    {
+                        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    transaction.Commit();
+                }
+            }
+            catch (SqlException e) when (e.Number == 2714 || e.Number == 1913) //Object already exists
+            {
+                //Table creation scripts are based on sys.objects metadata views.
+                //It looks that these views are not fully transactional and might
+                //not return information on already created table under heavy load.
+                //This in turn can result in executing table create or index create queries
+                //for objects that already exists. These queries will fail with
+                // 2714 (table) and 1913 (index) error codes.
+            }
+        }
+
+        CreateSqlConnection createSqlConnection;
+        string tableName;
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Transport.Msmq/ExceptionHeaderHelper.cs
@@ -1,0 +1,60 @@
+namespace NServiceBus.Transport.Msmq
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    static class ExceptionHeaderHelper
+    {
+        public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e)
+        {
+            headers["NServiceBus.ExceptionInfo.ExceptionType"] = e.GetType().FullName;
+
+            if (e.InnerException != null)
+            {
+                headers["NServiceBus.ExceptionInfo.InnerExceptionType"] = e.InnerException.GetType().FullName;
+            }
+
+            headers["NServiceBus.ExceptionInfo.HelpLink"] = e.HelpLink;
+            headers["NServiceBus.ExceptionInfo.Message"] = e.GetMessage().Truncate(16384);
+            headers["NServiceBus.ExceptionInfo.Source"] = e.Source;
+            headers["NServiceBus.ExceptionInfo.StackTrace"] = e.ToString();
+            headers["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
+
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (e.Data == null)
+            // ReSharper disable HeuristicUnreachableCode
+            {
+                return;
+            }
+            // ReSharper restore HeuristicUnreachableCode
+            foreach (DictionaryEntry entry in e.Data)
+            {
+                if (entry.Value == null)
+                {
+                    continue;
+                }
+                headers["NServiceBus.ExceptionInfo.Data." + entry.Key] = entry.Value.ToString();
+            }
+        }
+
+        static string GetMessage(this Exception exception)
+        {
+            try
+            {
+                return exception.Message;
+            }
+            catch (Exception)
+            {
+                return $"Could not read Message from exception type '{exception.GetType()}'.";
+            }
+        }
+
+        static string Truncate(this string value, int maxLength) =>
+            string.IsNullOrEmpty(value)
+                ? value
+                : value.Length <= maxLength
+                    ? value
+                    : value.Substring(0, maxLength);
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
+++ b/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
@@ -1,0 +1,53 @@
+namespace NServiceBus.Transport.Msmq
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Logging;
+
+    class FailureRateCircuitBreaker : IDisposable
+    {
+        public FailureRateCircuitBreaker(string name, int maximumFailuresPerSecond, Action<Exception> triggerAction)
+        {
+            this.name = name;
+            this.triggerAction = triggerAction;
+            maximumFailuresPerThirtySeconds = maximumFailuresPerSecond * 30;
+            timer = new Timer(_ => FlushHistory(), null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(30));
+        }
+
+        public void Dispose()
+        {
+            timer?.Dispose();
+        }
+
+        void FlushHistory()
+        {
+            Interlocked.Exchange(ref failureCount, 0);
+            Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+        }
+
+        public void Failure(Exception lastException)
+        {
+            var result = Interlocked.Increment(ref failureCount);
+            if (result > maximumFailuresPerThirtySeconds)
+            {
+                _ = Task.Run(() =>
+                {
+                    Logger.WarnFormat("The circuit breaker for {0} will now be triggered", name);
+                    triggerAction(lastException);
+                });
+            }
+            else if (result == 1)
+            {
+                Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
+            }
+        }
+
+        static readonly ILog Logger = LogManager.GetLogger<FailureRateCircuitBreaker>();
+        readonly string name;
+        readonly Action<Exception> triggerAction;
+        readonly int maximumFailuresPerThirtySeconds;
+        readonly Timer timer;
+        long failureCount;
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/MessagePump.cs
+++ b/src/NServiceBus.Transport.Msmq/MessagePump.cs
@@ -235,7 +235,9 @@ namespace NServiceBus.Transport.Msmq
             ResponseQueue = true,
             CorrelationId = true,
             Extension = true,
-            AppSpecific = true
+            AppSpecific = true,
+            UseJournalQueue = true,
+            UseDeadLetterQueue = true
         };
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqConfigurationExtensions.cs
@@ -184,5 +184,25 @@ namespace NServiceBus
             Guard.AgainstNull(nameof(config), config);
             config.GetSettings().Set("IgnoreIncomingTimeToBeReceivedHeaders", true);
         }
+
+        /// <summary>
+        /// Configures native delayed delivery.
+        /// </summary>
+        public static DelayedDeliverySettings NativeDelayedDelivery(this TransportExtensions<MsmqTransport> config, IDelayedMessageStore delayedMessageStore)
+        {
+            var sendOnlyEndpoint = config.GetSettings().GetOrDefault<bool>("Endpoint.SendOnly");
+            if (sendOnlyEndpoint)
+            {
+                throw new Exception("Delayed delivery is only supported for endpoints capable of receiving messages.");
+            }
+
+            //Enable hybrid mode in which timeout manager is still running in the core to process remaining timeouts.
+            config.GetSettings().Set("NServiceBus.TimeoutManager.EnableMigrationMode", true);
+
+            var delayedDeliverySettings = config.GetSettings().GetOrCreate<DelayedDeliverySettings>();
+            delayedDeliverySettings.DelayedMessageStore = delayedMessageStore;
+
+            return delayedDeliverySettings;
+        }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqSettings.cs
@@ -81,6 +81,12 @@ namespace NServiceBus.Transport.Msmq
                 DisableNativeTtbrInTransactions = disableNativeTtbrInTransactions;
             }
 
+            if (settings.TryGet<DelayedDeliverySettings>(out var delayedDeliverySettings))
+            {
+                UseNativeDelayedDelivery = true;
+                NativeDelayedDeliverySettings = delayedDeliverySettings;
+            }
+
             IgnoreIncomingTimeToBeReceivedHeaders = settings.GetOrDefault<bool>("IgnoreIncomingTimeToBeReceivedHeaders");
         }
 
@@ -107,5 +113,9 @@ namespace NServiceBus.Transport.Msmq
         public bool DisableNativeTtbrInTransactions { get; set; }
 
         public bool IgnoreIncomingTimeToBeReceivedHeaders { get; set; }
+
+        public bool UseNativeDelayedDelivery { get; set; }
+
+        public DelayedDeliverySettings NativeDelayedDeliverySettings { get; set; }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
@@ -72,7 +72,14 @@ transport.TimeToReachQueue(timespanValue);";
 
             settings.TryGetAuditMessageExpiration(out var auditMessageExpiration);
 
-            return new MsmqTransportInfrastructure(settings, msmqSettings, settings.Get<QueueBindings>(), isTransactional, outBoxRunning, auditMessageExpiration);
+            if (!settings.TryGet(out TransportTransactionMode requestedTransportTransactionMode))
+            {
+                requestedTransportTransactionMode = TransportTransactionMode.TransactionScope;
+            }
+
+            settings.TryGet("TransportPurgeOnStartupSettingsKey", out bool purgeOnStartup);
+
+            return new MsmqTransportInfrastructure(settings, msmqSettings, settings.Get<QueueBindings>(), isTransactional, outBoxRunning, auditMessageExpiration, () => settings.LogicalAddress(), settings.ErrorQueueAddress());
         }
 
         static bool IsTransactional(ReadOnlySettings settings)

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -82,16 +82,21 @@ namespace NServiceBus.Transport.Msmq
 
         static Dictionary<string, string> DeserializeMessageHeaders(Message m)
         {
+            return DeserializeMessageHeaders(m.Extension);
+        }
+
+        internal static Dictionary<string, string> DeserializeMessageHeaders(byte[] bytes)
+        {
             var result = new Dictionary<string, string>();
 
-            if (m.Extension.Length == 0)
+            if (bytes.Length == 0)
             {
                 return result;
             }
 
             //This is to make us compatible with v3 messages that are affected by this bug:
             //http://stackoverflow.com/questions/3779690/xml-serialization-appending-the-0-backslash-0-or-null-character
-            var data = m.Extension;
+            var data = bytes;
             var xmlLength = data.LastIndexOf(EndTag) + EndTag.Length; // Ignore any data after last </ArrayOfHeaderInfo>
             object o;
             using (var stream = new MemoryStream(buffer: data, index: 0, count: xmlLength, writable: false, publiclyVisible: true))
@@ -210,6 +215,7 @@ namespace NServiceBus.Transport.Msmq
             }
         }
 
+        public const string PropertyHeaderPrefix = "NServiceBus.Timeouts.Properties.";
         const string DIRECTPREFIX = "DIRECT=OS:";
         const string DIRECTPREFIX_TCP = "DIRECT=TCP:";
         internal const string PRIVATE = "\\private$\\";

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Description>MSMQ support for NServiceBus</Description>
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />
+    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.Msmq/NoTransactionStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/NoTransactionStrategy.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.Msmq
     using System;
     using System.Messaging;
     using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
     using Transport;
 
     class NoTransactionStrategy : ReceiveStrategy
@@ -22,11 +23,14 @@ namespace NServiceBus.Transport.Msmq
 
             var transportTransaction = new TransportTransaction();
 
+            var context = new ContextBag();
+            context.Set(message);
+
             using (var bodyStream = message.BodyStream)
             {
                 try
                 {
-                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction, context).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {

--- a/src/NServiceBus.Transport.Msmq/ReceiveOnlyNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/ReceiveOnlyNativeTransactionStrategy.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Messaging;
     using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
     using Transport;
 
     class ReceiveOnlyNativeTransactionStrategy : ReceiveStrategy
@@ -78,7 +79,10 @@
             {
                 using (var bodyStream = message.BodyStream)
                 {
-                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    var context = new ContextBag();
+                    context.Set(message);
+
+                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction, context).ConfigureAwait(false);
 
                     if (shouldAbortMessageProcessing)
                     {

--- a/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/ReceiveStrategy.cs
@@ -100,7 +100,7 @@ namespace NServiceBus.Transport.Msmq
             errorQueue.Send(message, transactionType);
         }
 
-        protected async Task<bool> TryProcessMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction)
+        protected async Task<bool> TryProcessMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction, ContextBag context)
         {
             if (discardExpiredTtbrMessages && TimeToBeReceived.HasElapsed(headers))
             {
@@ -111,7 +111,7 @@ namespace NServiceBus.Transport.Msmq
             using (var tokenSource = new CancellationTokenSource())
             {
                 var body = await ReadStream(bodyStream).ConfigureAwait(false);
-                var messageContext = new MessageContext(messageId, headers, body, transaction, tokenSource, new ContextBag());
+                var messageContext = new MessageContext(messageId, headers, body, transaction, tokenSource, context);
 
                 await onMessage(messageContext).ConfigureAwait(false);
 

--- a/src/NServiceBus.Transport.Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Transport.Msmq
     using System.Collections.Generic;
     using System.Messaging;
     using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
     using Transport;
 
     class SendsAtomicWithReceiveNativeTransactionStrategy : ReceiveStrategy
@@ -82,7 +83,10 @@ namespace NServiceBus.Transport.Msmq
             {
                 using (var bodyStream = message.BodyStream)
                 {
-                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    var context = new ContextBag();
+                    context.Set(message);
+
+                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction, context).ConfigureAwait(false);
 
                     if (shouldAbortMessageProcessing)
                     {

--- a/src/NServiceBus.Transport.Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.Transport.Msmq/TransactionScopeStrategy.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Transport.Msmq
     using System.Messaging;
     using System.Threading.Tasks;
     using System.Transactions;
+    using NServiceBus.Extensibility;
     using Transport;
 
     class TransactionScopeStrategy : ReceiveStrategy
@@ -79,7 +80,10 @@ namespace NServiceBus.Transport.Msmq
             {
                 using (var bodyStream = message.BodyStream)
                 {
-                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    var context = new ContextBag();
+                    context.Set(message);
+
+                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction, context).ConfigureAwait(false);
 
                     if (shouldAbortMessageProcessing)
                     {

--- a/src/NServiceBus.Transport.Msmq/Utils/Guard.cs
+++ b/src/NServiceBus.Transport.Msmq/Utils/Guard.cs
@@ -31,5 +31,17 @@
                 throw new ArgumentOutOfRangeException(argumentName);
             }
         }
+
+        public static void AgainstNegativeAndZero(string argumentName, int? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.Transport.Msmq/issues/324

Adds support for embedded timeouts to V7 of the transport. Can be used for migration and test purposes.