### PR TITLE
Packaging fixes

### DIFF
--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1900, 9.0.0)" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
-    <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="1.4.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.5.5" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Scripts\*.*" Pack="true" PackagePath="build\%(Filename)%(Extension)" />
+    <None Update="Scripts\*.*" Pack="true" PackagePath="build\$(TargetFramework)\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.Msmq/Scripts/NServiceBus.Transport.Msmq.props
+++ b/src/NServiceBus.Transport.Msmq/Scripts/NServiceBus.Transport.Msmq.props
@@ -1,12 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <ItemGroup>
     <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\*.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>NServiceBus.Transport.Msmq\%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Package content that goes into the `build` folder needs to be inside a TFM folder. This PR fixes that.

Also includes some cleanup and a bump to the latest Particular.Packaging.