### PR TITLE
Backport fixes for timeout poller and startup diagnostics bugs to release-2.0

### DIFF
--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/DueDelayedMessagePoller.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/DueDelayedMessagePoller.cs
@@ -172,6 +172,11 @@ namespace NServiceBus.Transport.Msmq.DelayedDelivery
             var waitTime = nextPoll - DateTimeOffset.UtcNow;
             if (waitTime > TimeSpan.Zero)
             {
+                if (waitTime > MaxSleepDuration)
+                {
+                    // Task.Delay() throws for times > int.MaxValue ms, which is ~24.85 days
+                    waitTime = MaxSleepDuration;
+                }
                 return Task.Delay(waitTime, cancellationToken);
             }
 

--- a/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqTransport.cs
@@ -159,7 +159,7 @@ namespace NServiceBus
                 UseDeadLetterQueueForMessagesWithTimeToBeReceived,
                 TimeToReachQueue = GetFormattedTimeToReachQueue(TimeToReachQueue),
                 TimeoutQueue = delayedDeliveryMessagePump?.ReceiveAddress,
-                TimeoutStorageType = DelayedDelivery?.DelayedMessageStore?.GetType(),
+                TimeoutStorageType = DelayedDelivery?.DelayedMessageStore?.GetType()?.FullName,
             });
 
             var infrastructure = new MsmqTransportInfrastructure(messageReceivers, dispatcher, delayedDeliveryPump);


### PR DESCRIPTION
* Backports fix for https://github.com/Particular/NServiceBus.Transport.Msmq/issues/607 from https://github.com/Particular/NServiceBus.Transport.Msmq/pull/608 to `release-2.0`
* Backports MSMQ-only fix for https://github.com/Particular/NServiceBus/issues/6813 from https://github.com/Particular/NServiceBus.Transport.Msmq/pull/608 to `release-2.0`