### PR TITLE
Backport fixes for timeout poller to release-1.2

### DIFF
--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/DueDelayedMessagePoller.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/DueDelayedMessagePoller.cs
@@ -174,6 +174,11 @@ namespace NServiceBus.Transport.Msmq.DelayedDelivery
             var waitTime = nextPoll - DateTimeOffset.UtcNow;
             if (waitTime > TimeSpan.Zero)
             {
+                if (waitTime > MaxSleepDuration)
+                {
+                    // Task.Delay() throws for times > int.MaxValue ms, which is ~24.85 days
+                    waitTime = MaxSleepDuration;
+                }
                 return Task.Delay(waitTime, cancellationToken);
             }
 


### PR DESCRIPTION
* Backports fix for https://github.com/Particular/NServiceBus.Transport.Msmq/issues/607 from https://github.com/Particular/NServiceBus.Transport.Msmq/pull/608 to `release-1.2`

Note that 1.2.x does not add startup diagnostics so the partial MSMQ-only fix for https://github.com/Particular/NServiceBus/issues/6813 is not included in this backport.