### PR TITLE
Stop flooding logs in FailureRateCircuitBreaker

### DIFF
--- a/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
+++ b/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
@@ -27,8 +27,8 @@ namespace NServiceBus.Transport.Msmq
 
         public void Failure(Exception lastException)
         {
-            var result = Interlocked.Increment(ref failureCount);
-            if (result > maximumFailuresPerThirtySeconds)
+            var failures = Interlocked.Increment(ref failureCount);
+            if (failures > maximumFailuresPerThirtySeconds)
             {
                 _ = Task.Run(() =>
                 {
@@ -36,7 +36,7 @@ namespace NServiceBus.Transport.Msmq
                     triggerAction(lastException);
                 });
             }
-            else if (result == 1)
+            else if (failures == 1)
             {
                 Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
             }

--- a/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
+++ b/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
@@ -15,10 +15,7 @@ namespace NServiceBus.Transport.Msmq
             timer = new Timer(_ => FlushHistory(), null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(30));
         }
 
-        public void Dispose()
-        {
-            timer?.Dispose();
-        }
+        public void Dispose() => timer.Dispose();
 
         void FlushHistory()
         {

--- a/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
+++ b/src/NServiceBus.Transport.Msmq/FailureRateCircuitBreaker.cs
@@ -22,8 +22,10 @@ namespace NServiceBus.Transport.Msmq
 
         void FlushHistory()
         {
-            Interlocked.Exchange(ref failureCount, 0);
-            Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+            if (Interlocked.Exchange(ref failureCount, 0) > 0)
+            {
+                Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+            }
         }
 
         public void Failure(Exception lastException)


### PR DESCRIPTION
The timer callback was previously reporting an INFO message every 30 seconds. Now only logged if the circuit breaker was previously set due to a failure.