### PR TITLE
Flow Particular.Msmq content to consumers of transport package

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/NServiceBus.Transport.Msmq.AcceptanceTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NServiceBus.Transport.Msmq\NServiceBus.Transport.Msmq.csproj" />
+    <ProjectReference Include="..\NServiceBus.Transport.Msmq\NServiceBus.Transport.Msmq.csproj" ExcludeAssets="contentFiles;build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
+++ b/src/NServiceBus.Transport.Msmq.Tests/NServiceBus.Transport.Msmq.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NServiceBus.Transport.Msmq\NServiceBus.Transport.Msmq.csproj" />
+    <ProjectReference Include="..\NServiceBus.Transport.Msmq\NServiceBus.Transport.Msmq.csproj" ExcludeAssets="contentFiles;build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NServiceBus.Transport.Msmq\NServiceBus.Transport.Msmq.csproj" />
+    <ProjectReference Include="..\NServiceBus.Transport.Msmq\NServiceBus.Transport.Msmq.csproj" ExcludeAssets="contentFiles;build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.Sources.props
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.Sources.props
@@ -1,8 +1,8 @@
 <Project>
 
   <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)endpoints.xsd" LogicalName="Msmq.InstanceMapping.Validators.endpoints.xsd" />
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)endpointsV2.xsd" LogicalName="Msmq.InstanceMapping.Validators.endpointsV2.xsd" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)endpoints.xsd" LogicalName="Msmq.InstanceMapping.Validators.endpoints.xsd" Visible="false" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)endpointsV2.xsd" LogicalName="Msmq.InstanceMapping.Validators.endpointsV2.xsd" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
+++ b/src/NServiceBus.Transport.Msmq/NServiceBus.Transport.Msmq.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.0.0-alpha.9" />
-    <PackageReference Include="Particular.Msmq" Version="1.0.0-alpha.1" />
+    <PackageReference Include="Particular.Msmq" Version="1.0.0-alpha.1" PrivateAssets="None" />
     <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Follow-up to #634 

This change ensures that projects that consume the transport source package also get all of the source files in the Particular.Msmq package added to the project as well.

It also includes a smaller change that hides the two embedded instance mapping files in the Solution Explorer of the consuming project.