### PR TITLE
Delayed delivery constraints are not respected for messages sent from handlers

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_in_a_handler.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_in_a_handler.cs
@@ -1,0 +1,89 @@
+﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Logging;
+    using NUnit.Framework;
+
+    class When_deferring_a_message_in_a_handler
+    {
+        [Test]
+        public async Task Delay_should_be_applied()
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            Log.Info($"First message sent at {now:O}");
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    return session.SendLocal(new MyMessage());
+                }))
+                .Done(c => c.DelayedMessageProcessed)
+                .Run();
+
+            Log.Info($"Delayed message processed at {context.DelayedMessageProcessedAt:O}");
+
+            Assert.True(context.DelayedMessageProcessed);
+            Assert.GreaterOrEqual(context.DelayedMessageProcessedAt, now.Add(Endpoint.Delay));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DelayedMessageProcessed { get; set; }
+            public DateTimeOffset DelayedMessageProcessedAt { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public static TimeSpan Delay = TimeSpan.FromSeconds(10);
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
+                {
+                    var context = (Context)run.ScenarioContext;
+                    var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+
+                    var delayedDeliverySettings = transport.NativeDelayedDelivery(new SqlServerDelayedMessageStore(ConfigureEndpointMsmqTransport.GetStorageConnectionString()));
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public async Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    if (message.SentFromHandler)
+                    {
+                        testContext.DelayedMessageProcessed = true;
+                        testContext.DelayedMessageProcessedAt = DateTimeOffset.Now;
+
+                        return;
+                    }
+
+                    var options = new SendOptions();
+                    options.DelayDeliveryWith(Delay);
+                    options.RouteToThisEndpoint();
+
+                    await context.Send(new MyMessage { SentFromHandler = true }, options);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+            public bool SentFromHandler { get; set; }
+        }
+
+        static readonly ILog Log = LogManager.GetLogger<When_deferring_a_message_in_a_handler>();
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqMessageDispatcher.cs
@@ -65,11 +65,11 @@ namespace NServiceBus.Transport.Msmq
         void ExecuteTransportOperation(TransportTransaction transaction, UnicastTransportOperation transportOperation, ContextBag context)
         {
             DateTimeOffset? deliverAt = null;
-            if (timeoutsQueue != null && context.TryGetDeliveryConstraint<DoNotDeliverBefore>(out var doNotDeliverBefore))
+            if (timeoutsQueue != null && transportOperation.DeliveryConstraints.TryGet(out DoNotDeliverBefore doNotDeliverBefore))
             {
                 deliverAt = doNotDeliverBefore.At;
             }
-            else if (timeoutsQueue != null && context.TryGetDeliveryConstraint<DelayDeliveryWith>(out var delayDeliveryWith))
+            else if (timeoutsQueue != null && transportOperation.DeliveryConstraints.TryGet(out DelayDeliveryWith delayDeliveryWith))
             {
                 deliverAt = DateTimeOffset.UtcNow + delayDeliveryWith.Delay;
             }


### PR DESCRIPTION
### Description

The transport does not respect `DelayedDelivery` constraints, passed via `SendOptions` for send operations executing the message processing pipeline. This includes, among others, message handlers and sagas.

As a result, messages are delivered immediately without any delay.  

### Affected versions
- `1.2.*`