### PR TITLE
Do not emit BOM when serializing message headers

### DIFF
--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
@@ -123,7 +123,7 @@
         }
 
         [Test]
-        public void Should_not_emit_bom_when_serializing_headers_for_backwards_compatibility()
+        public void Should_not_emit_BOM_when_serializing_headers_for_backwards_compatibility()
         {
             var message =
                 MsmqUtilities.Convert(
@@ -137,7 +137,7 @@
         }
 
         [Test]
-        public void Version_1_and_2_does_not_emit_bom_in_headers()
+        public void Verify_that_Version_1_and_2_does_not_emit_BOM_in_headers()
         {
             var headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
             var headers = new Dictionary<string, string> { { "some-header", "some value" } };

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
@@ -147,6 +147,9 @@
                 Value = pair.Value
             }).ToList();
 
+            // this is a copy of what v1 and v2 of the transport does
+            // https://github.com/Particular/NServiceBus.Transport.Msmq/blob/release-2.0/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs#L131
+            // https://github.com/Particular/NServiceBus.Transport.Msmq/blob/release-1.2/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs#L144
             using (var stream = new MemoryStream())
             {
                 headerSerializer.Serialize(stream, wrappedHeaders);

--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
     using NUnit.Framework;
     using Particular.Msmq;
     using Support;
@@ -117,6 +119,20 @@
             Dictionary<string, string> headers = MsmqUtilities.ExtractHeaders(message);
 
             Assert.AreEqual(expected, headers["NServiceBus.ExceptionInfo.Message"]);
+        }
+
+        [Test]
+        public void Should_not_emit_bom_when_serializing_headers_for_backwards_compatibility()
+        {
+            var message =
+                MsmqUtilities.Convert(
+                    new OutgoingMessage("message id",
+                        new Dictionary<string, string> { { "some-header", "some value" } }, Array.Empty<byte>()));
+
+            var enc = new UTF8Encoding(true);
+            var preamble = enc.GetPreamble();
+
+            Assert.AreNotEqual(preamble, message.Extension.Take(preamble.Length));
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -110,8 +110,6 @@ namespace NServiceBus.Transport.Msmq
             return result;
         }
 
-        static XmlWriterSettings HeaderSerializerXmlWriterSettings = new XmlWriterSettings { CheckCharacters = false, Encoding = new UTF8Encoding(false) };
-
         public static Message Convert(OutgoingMessage message)
         {
             var result = new Message();
@@ -209,6 +207,7 @@ namespace NServiceBus.Transport.Msmq
         const string DIRECTPREFIX_TCP = "DIRECT=TCP:";
         internal const string PRIVATE = "\\private$\\";
 
+        static XmlWriterSettings HeaderSerializerXmlWriterSettings = new XmlWriterSettings { CheckCharacters = false, Encoding = new UTF8Encoding(false) };
         static System.Xml.Serialization.XmlSerializer headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
         static ILog Logger = LogManager.GetLogger<MsmqUtilities>();
         static byte[] EndTag = Encoding.UTF8.GetBytes("</ArrayOfHeaderInfo>");

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -110,6 +110,8 @@ namespace NServiceBus.Transport.Msmq
             return result;
         }
 
+        static XmlWriterSettings HeaderSerializerXmlWriterSettings = new XmlWriterSettings { CheckCharacters = false, Encoding = new UTF8Encoding(false) };
+
         public static Message Convert(OutgoingMessage message)
         {
             var result = new Message();
@@ -127,11 +129,7 @@ namespace NServiceBus.Transport.Msmq
 
             using (var stream = new MemoryStream())
             {
-                using var writer = XmlWriter.Create(stream, new XmlWriterSettings
-                {
-                    CheckCharacters = false,
-                    //Encoding = new UTF8Encoding(false), this fixes it
-                });
+                using var writer = XmlWriter.Create(stream, HeaderSerializerXmlWriterSettings);
 
                 var headers = message.Headers.Select(pair => new HeaderInfo
                 {

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -127,7 +127,11 @@ namespace NServiceBus.Transport.Msmq
 
             using (var stream = new MemoryStream())
             {
-                using var writer = XmlWriter.Create(stream, new XmlWriterSettings { CheckCharacters = false });
+                using var writer = XmlWriter.Create(stream, new XmlWriterSettings
+                {
+                    CheckCharacters = false,
+                    //Encoding = new UTF8Encoding(false), this fixes it
+                });
 
                 var headers = message.Headers.Select(pair => new HeaderInfo
                 {

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -207,8 +207,8 @@ namespace NServiceBus.Transport.Msmq
         const string DIRECTPREFIX_TCP = "DIRECT=TCP:";
         internal const string PRIVATE = "\\private$\\";
 
-        static XmlReaderSettings HeaderSerializerXmlReaderSettings = new XmlReaderSettings { CheckCharacters = false };
-        static XmlWriterSettings HeaderSerializerXmlWriterSettings = new XmlWriterSettings { CheckCharacters = false, Encoding = new UTF8Encoding(false) };
+        static readonly XmlReaderSettings HeaderSerializerXmlReaderSettings = new XmlReaderSettings { CheckCharacters = false };
+        static readonly XmlWriterSettings HeaderSerializerXmlWriterSettings = new XmlWriterSettings { CheckCharacters = false, Encoding = new UTF8Encoding(false) };
         static System.Xml.Serialization.XmlSerializer headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
         static ILog Logger = LogManager.GetLogger<MsmqUtilities>();
         static byte[] EndTag = Encoding.UTF8.GetBytes("</ArrayOfHeaderInfo>");

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -94,7 +94,7 @@ namespace NServiceBus.Transport.Msmq
 
             using (var stream = new MemoryStream(buffer: data, index: 0, count: xmlLength, writable: false, publiclyVisible: true))
             {
-                using var reader = XmlReader.Create(stream, new XmlReaderSettings { CheckCharacters = false });
+                using var reader = XmlReader.Create(stream, HeaderSerializerXmlReaderSettings);
 
                 o = headerSerializer.Deserialize(reader);
             }
@@ -207,6 +207,7 @@ namespace NServiceBus.Transport.Msmq
         const string DIRECTPREFIX_TCP = "DIRECT=TCP:";
         internal const string PRIVATE = "\\private$\\";
 
+        static XmlReaderSettings HeaderSerializerXmlReaderSettings = new XmlReaderSettings { CheckCharacters = false };
         static XmlWriterSettings HeaderSerializerXmlWriterSettings = new XmlWriterSettings { CheckCharacters = false, Encoding = new UTF8Encoding(false) };
         static System.Xml.Serialization.XmlSerializer headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
         static ILog Logger = LogManager.GetLogger<MsmqUtilities>();


### PR DESCRIPTION
### Versions affected

The following MSMQ transport versions will not deserialize MSMQ headers correctly when the data contains a BOM:

- NServiceBus.Transport.Msmq v1.0.X (Compatible with core v7)
- NServiceBus v6.X (msmq bundled in core)
- NServiceBus v5.X (msmq bundled in core)

These versions were using `Encoding.UTF8.GetString` to get the data to deserialize via `XmlReader which can't handle a BOM.

NServiceBus.Transport.Msmq version 1.1.0 contains a change to be more liberal in receiving header data that have trailing bytes. That change also made the transport in being liberal in receiving headers with or without a BOM:

- https://github.com/Particular/NServiceBus.Transport.Msmq/pull/125

