### PR TITLE
Byte order mark (BOM) is emitted when serializing message headers

### DIFF
--- a/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/MsmqUtilitiesTests.cs
@@ -2,6 +2,10 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Xml;
     using NUnit.Framework;
     using Particular.Msmq;
     using Support;
@@ -117,6 +121,68 @@
             Dictionary<string, string> headers = MsmqUtilities.ExtractHeaders(message);
 
             Assert.AreEqual(expected, headers["NServiceBus.ExceptionInfo.Message"]);
+        }
+
+        [Test]
+        public void Should_not_emit_BOM_when_serializing_headers_for_backwards_compatibility()
+        {
+            // This test ensures that older versions of the transport can still parse the headers since that code can't handle a BOM 
+            // v1.0.X - https://github.com/Particular/NServiceBus.Transport.Msmq/blob/1.0.2/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs#L94
+            // v6 with msmq bundled - https://github.com/Particular/NServiceBus/blob/6.5.10/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs#L98
+            // v5 with msmq bundled - https://github.com/Particular/NServiceBus/blob/5.2.26/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs#L199
+            // Note: As of v1.1 the transport can handle a BOM due to this change - https://github.com/Particular/NServiceBus.Transport.Msmq/pull/125
+
+            var message =
+                MsmqUtilities.Convert(
+                    new OutgoingMessage("message id",
+                        new Dictionary<string, string> { { "some-header", "some value" } }, Array.Empty<byte>()));
+
+            var encodingWithBOM = new UTF8Encoding(true);
+            var preamble = encodingWithBOM.GetPreamble();
+
+            Assert.AreNotEqual(preamble, message.Extension.Take(preamble.Length));
+        }
+
+        [Test]
+        public void Default_usage_of_xml_serializer_does_not_emit_bom()
+        {
+            // Older versions of the transport doesn't use XmlWriter settings and therefor no BOM is emitted. This test verified that behavior
+
+            var serializer = new System.Xml.Serialization.XmlSerializer(typeof(string));
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(stream, "test");
+
+                var seralizedHeaders = stream.ToArray();
+
+                var encodingWithBOM = new UTF8Encoding(true);
+                var preamble = encodingWithBOM.GetPreamble();
+
+                Assert.AreNotEqual(preamble, seralizedHeaders.Take(preamble.Length));
+            }
+        }
+
+        [Test]
+        public void Default_xmlwritersettings_emit_bom()
+        {
+            // This test docments that the default XmlWriterSettings emits a BOM by default
+
+            var serializer = new System.Xml.Serialization.XmlSerializer(typeof(string));
+
+            using (var stream = new MemoryStream())
+            {
+                using var writer = XmlWriter.Create(stream, new XmlWriterSettings());
+
+                serializer.Serialize(writer, "test");
+
+                var seralizedHeaders = stream.ToArray();
+
+                var encodingWithBOM = new UTF8Encoding(true);
+                var preamble = encodingWithBOM.GetPreamble();
+
+                Assert.AreEqual(preamble, seralizedHeaders.Take(preamble.Length));
+            }
         }
     }
 }

--- a/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqUtilities.cs
@@ -94,7 +94,7 @@ namespace NServiceBus.Transport.Msmq
 
             using (var stream = new MemoryStream(buffer: data, index: 0, count: xmlLength, writable: false, publiclyVisible: true))
             {
-                using var reader = XmlReader.Create(stream, new XmlReaderSettings { CheckCharacters = false });
+                using var reader = XmlReader.Create(stream, HeaderSerializerXmlReaderSettings);
 
                 o = headerSerializer.Deserialize(reader);
             }
@@ -127,7 +127,7 @@ namespace NServiceBus.Transport.Msmq
 
             using (var stream = new MemoryStream())
             {
-                using var writer = XmlWriter.Create(stream, new XmlWriterSettings { CheckCharacters = false });
+                using var writer = XmlWriter.Create(stream, HeaderSerializerXmlWriterSettings);
 
                 var headers = message.Headers.Select(pair => new HeaderInfo
                 {
@@ -207,6 +207,8 @@ namespace NServiceBus.Transport.Msmq
         const string DIRECTPREFIX_TCP = "DIRECT=TCP:";
         internal const string PRIVATE = "\\private$\\";
 
+        static readonly XmlReaderSettings HeaderSerializerXmlReaderSettings = new XmlReaderSettings { CheckCharacters = false };
+        static readonly XmlWriterSettings HeaderSerializerXmlWriterSettings = new XmlWriterSettings { CheckCharacters = false, Encoding = new UTF8Encoding(false) };
         static System.Xml.Serialization.XmlSerializer headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
         static ILog Logger = LogManager.GetLogger<MsmqUtilities>();
         static byte[] EndTag = Encoding.UTF8.GetBytes("</ArrayOfHeaderInfo>");


### PR DESCRIPTION
This causes older versions of the transport (see below) that is not expecting a BOM to throw when attempting to deserializer message headers:

```
2024-05-24 09:50:35.097 WARN  Message '7e47b130-25e6-4b43-baf0-2339b773687a\105607' has corrupted headers
System.InvalidOperationException: There is an error in XML document (1, 1). ---> System.Xml.XmlException: Data at the root level is invalid. Line 1, position 1.
   at System.Xml.XmlTextReaderImpl.Throw(Exception e)
   at System.Xml.XmlTextReaderImpl.ParseRootLevelWhitespace()
   at System.Xml.XmlTextReaderImpl.ParseDocumentContent()
   at System.Xml.XmlReader.MoveToContent()
   at Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializationReaderList1.Read3_ArrayOfHeaderInfo()
   --- End of inner exception stack trace ---
   at System.Xml.Serialization.XmlSerializer.Deserialize(XmlReader xmlReader, String encodingStyle, XmlDeserializationEvents events)
   at NServiceBus.Transport.Msmq.MsmqUtilities.DeserializeMessageHeaders(Message m)
   at NServiceBus.Transport.Msmq.MsmqUtilities.ExtractHeaders(Message msmqMessage)
   at NServiceBus.Transport.Msmq.ReceiveStrategy.TryExtractHeaders(Message message, Dictionary`2& headers)
```

### Root cause

These versions were using `Encoding.UTF8.GetString` to get the data to deserialize via `XmlReader which can't handle a BOM.

### Versions affected

- NServiceBus.Transport.Msmq v1.0.X (Compatible with core v7)
- NServiceBus v6.X (msmq bundled in core)
- NServiceBus v5.X (msmq bundled in core)


### Notes

NServiceBus.Transport.Msmq version 1.1.0 contains a change to be more liberal in receiving header data that have trailing bytes. That change also made the transport in being liberal in receiving headers with or without a BOM:

- https://github.com/Particular/NServiceBus.Transport.Msmq/pull/125

