### PR TITLE
Delayed delivery: split setup from initialize

### DIFF
--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_batch_of_messages.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_batch_of_messages.cs
@@ -110,7 +110,7 @@
                 {
                     var context = (Context)run.ScenarioContext;
                     var transport = endpointConfiguration.ConfigureTransport<MsmqTransport>();
-                    var storage = new WrapDelayedMessageStore(transport.DelayedDelivery.DelayedMessageStore, context);
+                    var storage = new WrapDelayedMessageStore((IDelayedMessageStoreWithInfrastructure)transport.DelayedDelivery.DelayedMessageStore, context);
                     transport.DelayedDelivery =
                         new DelayedDeliverySettings(storage)
                         {
@@ -141,12 +141,12 @@
         {
         }
 
-        class WrapDelayedMessageStore : IDelayedMessageStore
+        class WrapDelayedMessageStore : IDelayedMessageStoreWithInfrastructure
         {
-            readonly IDelayedMessageStore delayedMessageStoreImplementation;
+            readonly IDelayedMessageStoreWithInfrastructure delayedMessageStoreImplementation;
             readonly Context context;
 
-            public WrapDelayedMessageStore(IDelayedMessageStore impl, Context context)
+            public WrapDelayedMessageStore(IDelayedMessageStoreWithInfrastructure impl, Context context)
             {
                 this.context = context;
                 delayedMessageStoreImplementation = impl;
@@ -154,6 +154,9 @@
 
             public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
                 => delayedMessageStoreImplementation.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public Task SetupInfrastructure(CancellationToken cancellationToken = default)
+                => delayedMessageStoreImplementation.SetupInfrastructure(cancellationToken);
 
             public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
                 => delayedMessageStoreImplementation.Next(cancellationToken);

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_and_storage_is_unavailable.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_and_storage_is_unavailable.cs
@@ -58,7 +58,7 @@
                     });
                     var transport = endpointConfiguration.ConfigureTransport<MsmqTransport>();
                     transport.DelayedDelivery =
-                        new DelayedDeliverySettings(new FaultyDelayedMessageStore(transport.DelayedDelivery.DelayedMessageStore))
+                        new DelayedDeliverySettings(new FaultyDelayedMessageStore((IDelayedMessageStoreWithInfrastructure)transport.DelayedDelivery.DelayedMessageStore))
                         {
                             NumberOfRetries = 2,
                             TimeToTriggerStoreCircuitBreaker = TimeSpan.FromSeconds(5)
@@ -111,17 +111,20 @@
         {
         }
 
-        class FaultyDelayedMessageStore : IDelayedMessageStore
+        class FaultyDelayedMessageStore : IDelayedMessageStoreWithInfrastructure
         {
-            IDelayedMessageStore impl;
+            IDelayedMessageStoreWithInfrastructure impl;
 
-            public FaultyDelayedMessageStore(IDelayedMessageStore impl)
+            public FaultyDelayedMessageStore(IDelayedMessageStoreWithInfrastructure impl)
             {
                 this.impl = impl;
             }
 
             public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
                 => impl.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public Task SetupInfrastructure(CancellationToken cancellationToken = default)
+                => impl.SetupInfrastructure(cancellationToken);
 
             public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default) => impl.Next(cancellationToken);
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_deferring_a_message_while_poller_sleeps.cs
@@ -57,7 +57,7 @@
                 EndpointSetup<DefaultServer>((endpointConfiguration, run) =>
                 {
                     var transport = endpointConfiguration.ConfigureTransport<MsmqTransport>();
-                    transport.DelayedDelivery = new DelayedDeliverySettings(new TestDelayedMessageStore(transport.DelayedDelivery.DelayedMessageStore, (Context)run.ScenarioContext));
+                    transport.DelayedDelivery = new DelayedDeliverySettings(new TestDelayedMessageStore((IDelayedMessageStoreWithInfrastructure)transport.DelayedDelivery.DelayedMessageStore, (Context)run.ScenarioContext));
                 });
             }
 
@@ -82,12 +82,12 @@
         {
         }
 
-        class TestDelayedMessageStore : IDelayedMessageStore
+        class TestDelayedMessageStore : IDelayedMessageStoreWithInfrastructure
         {
-            readonly IDelayedMessageStore impl;
+            readonly IDelayedMessageStoreWithInfrastructure impl;
             readonly Context context;
 
-            public TestDelayedMessageStore(IDelayedMessageStore impl, Context context)
+            public TestDelayedMessageStore(IDelayedMessageStoreWithInfrastructure impl, Context context)
             {
                 this.impl = impl;
                 this.context = context;
@@ -95,6 +95,9 @@
 
             public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
                 => impl.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public Task SetupInfrastructure(CancellationToken cancellationToken = default)
+                => impl.SetupInfrastructure(cancellationToken);
 
             public async Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
             {

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
@@ -64,7 +64,7 @@
                     });
                     var transport = endpointConfiguration.ConfigureTransport<MsmqTransport>();
                     transport.DelayedDelivery =
-                        new DelayedDeliverySettings(new FaultyDelayedMessageStore(transport.DelayedDelivery.DelayedMessageStore))
+                        new DelayedDeliverySettings(new FaultyDelayedMessageStore((IDelayedMessageStoreWithInfrastructure)transport.DelayedDelivery.DelayedMessageStore))
                         {
                             NumberOfRetries = 1,
                             TimeToTriggerStoreCircuitBreaker = TimeSpan.FromSeconds(5)
@@ -113,16 +113,18 @@
             }
         }
 
-        class FaultyDelayedMessageStore : IDelayedMessageStore
+        class FaultyDelayedMessageStore : IDelayedMessageStoreWithInfrastructure
         {
-            IDelayedMessageStore impl;
+            IDelayedMessageStoreWithInfrastructure impl;
 
-            public FaultyDelayedMessageStore(IDelayedMessageStore impl)
+            public FaultyDelayedMessageStore(IDelayedMessageStoreWithInfrastructure impl)
             {
                 this.impl = impl;
             }
 
             public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default) => impl.Initialize(endpointName, transactionMode, cancellationToken);
+
+            public Task SetupInfrastructure(CancellationToken cancellationToken = default) => impl.SetupInfrastructure(cancellationToken);
 
             public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default) => impl.Next(cancellationToken);
 

--- a/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
+++ b/src/NServiceBus.Transport.Msmq.AcceptanceTests/When_handling_delayed_delivery_errors_fail.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Runtime.ExceptionServices;
     using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -15,30 +16,41 @@
         [Test]
         public async Task Should_trigger_circuit_breaker()
         {
-            AppDomain.CurrentDomain.FirstChanceException += (sender, args) => Console.WriteLine("\nFirstChanceException\n" + args.Exception.ToString().Replace("\n", "\n\t") + new StackTrace(args.Exception, 1).ToString().Replace("\n", "\n\t"));
             Requires.DelayedDelivery();
 
-            var delay = TimeSpan.FromSeconds(5); // High value needed as most transports have multi second delay latency by default
+            try
+            {
+                AppDomain.CurrentDomain.FirstChanceException += HandleFirstChangeException;
 
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
-                {
-                    var options = new SendOptions();
+                var delay = TimeSpan.FromSeconds(5); // High value needed as most transports have multi second delay latency by default
 
-                    options.DelayDeliveryWith(delay);
-                    options.RouteToThisEndpoint();
+                var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                    {
+                        var options = new SendOptions();
 
-                    return session.Send(new MyMessage(), options);
-                }).DoNotFailOnErrorMessages())
-                .WithEndpoint<ErrorSpy>()
-                .Done(c => c.CriticalActionCalled)
-                .Run();
+                        options.DelayDeliveryWith(delay);
+                        options.RouteToThisEndpoint();
 
-            Assert.False(context.Processed, nameof(context.Processed)); // When remove fails dispatch should be rolled back
-            Assert.False(context.MovedToErrorQueue, nameof(context.MovedToErrorQueue));
-            Assert.True(context.CriticalActionCalled, nameof(context.CriticalActionCalled));
-            StringAssert.AreEqualIgnoringCase("Failed to execute error handling for delayed message forwarding", context.FailureMessage);
+                        return session.Send(new MyMessage(), options);
+                    }).DoNotFailOnErrorMessages())
+                    .WithEndpoint<ErrorSpy>()
+                    .Done(c => c.CriticalActionCalled)
+                    .Run();
+
+                Assert.False(context.Processed, nameof(context.Processed)); // When remove fails dispatch should be rolled back
+                Assert.False(context.MovedToErrorQueue, nameof(context.MovedToErrorQueue));
+                Assert.True(context.CriticalActionCalled, nameof(context.CriticalActionCalled));
+                StringAssert.AreEqualIgnoringCase("Failed to execute error handling for delayed message forwarding", context.FailureMessage);
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.FirstChanceException -= HandleFirstChangeException;
+            }
         }
+
+        static void HandleFirstChangeException(object sender, FirstChanceExceptionEventArgs args)
+            => Console.WriteLine("\nFirstChanceException\n" + args.Exception.ToString().Replace("\n", "\n\t") + new StackTrace(args.Exception, 1).ToString().Replace("\n", "\n\t"));
 
         public class Context : ScenarioContext
         {

--- a/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.Msmq.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -43,6 +43,10 @@ namespace NServiceBus
         System.Threading.Tasks.Task<bool> Remove(NServiceBus.DelayedMessage entity, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Store(NServiceBus.DelayedMessage entity, System.Threading.CancellationToken cancellationToken = default);
     }
+    public interface IDelayedMessageStoreWithInfrastructure : NServiceBus.IDelayedMessageStore
+    {
+        System.Threading.Tasks.Task SetupInfrastructure(System.Threading.CancellationToken cancellationToken = default);
+    }
     public class InstanceMappingFileSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public InstanceMappingFileSettings(NServiceBus.Settings.SettingsHolder settings) { }
@@ -110,7 +114,7 @@ namespace NServiceBus
             ".0.", false)]
         public override string ToTransportAddress(NServiceBus.Transport.QueueAddress address) { }
     }
-    public class SqlServerDelayedMessageStore : NServiceBus.IDelayedMessageStore
+    public class SqlServerDelayedMessageStore : NServiceBus.IDelayedMessageStore, NServiceBus.IDelayedMessageStoreWithInfrastructure
     {
         public SqlServerDelayedMessageStore(NServiceBus.CreateSqlConnection connectionFactory, string schema = null, string tableName = null) { }
         public SqlServerDelayedMessageStore(string connectionString, string schema = null, string tableName = null) { }
@@ -119,6 +123,7 @@ namespace NServiceBus
         public System.Threading.Tasks.Task Initialize(string queueName, NServiceBus.TransportTransactionMode transactionMode, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<System.DateTimeOffset?> Next(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<bool> Remove(NServiceBus.DelayedMessage timeout, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task SetupInfrastructure(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task Store(NServiceBus.DelayedMessage timeout, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }

--- a/src/NServiceBus.Transport.Msmq.Tests/DelayedDeliveryStoreInitializationTests.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/DelayedDeliveryStoreInitializationTests.cs
@@ -1,0 +1,103 @@
+﻿namespace NServiceBus.Transport.Msmq.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class DelayedDeliveryStoreInitializationTests
+    {
+        [TestCase(true, true, ExpectedResult = true)]
+        [TestCase(true, false, ExpectedResult = false)]
+        [TestCase(false, true, ExpectedResult = false)]
+        [TestCase(false, false, ExpectedResult = false)]
+        public async Task<bool> Should_only_call_initialize_on_legacy_interface_when_configured_to_create_queues(bool setupInfrastrutcure, bool createQueues)
+        {
+            var messageStore = new FakeDelayedMessageStore();
+
+            await InitializeTransport(messageStore, setupInfrastrutcure, createQueues);
+
+            return messageStore.WasInitialized;
+        }
+
+
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(false, false)]
+        public async Task Should_always_call_initialize_on_new_interface(bool setupInfrastrutcure, bool createQueues)
+        {
+            var messageStore = new FakeDelayedMessageStoreWithInfrastructure();
+
+            await InitializeTransport(messageStore, setupInfrastrutcure, createQueues);
+
+            Assert.That(messageStore.WasInitialized, Is.True);
+        }
+
+        [TestCase(true, true, ExpectedResult = true)]
+        [TestCase(true, false, ExpectedResult = false)]
+        [TestCase(false, true, ExpectedResult = false)]
+        [TestCase(false, false, ExpectedResult = false)]
+        public async Task<bool> Should_only_call_setup_infrastructure_on_new_interface_when_configured_to_create_queues(bool setupInfrastructure, bool createQueues)
+        {
+            var messageStore = new FakeDelayedMessageStoreWithInfrastructure();
+
+            await InitializeTransport(messageStore, setupInfrastructure, createQueues);
+
+            return messageStore.SetupInfrastructureCalled;
+        }
+
+        async Task InitializeTransport(IDelayedMessageStore messageStore, bool setupInfrastructure, bool createQueues, CancellationToken cancellationToken = default)
+        {
+            var transport = new MsmqTransport
+            {
+                DelayedDelivery = new DelayedDeliverySettings(messageStore),
+                CreateQueues = createQueues
+            };
+
+            var hostSettings = new HostSettings("Test", "Test", new StartupDiagnosticEntries(), CriticalErrorAction, setupInfrastructure);
+
+            var recievers = new ReceiveSettings[]
+            {
+                new ReceiveSettings("Main", new QueueAddress("Test"), false, false, "error")
+            };
+
+            var sendingAddresses = Array.Empty<string>();
+
+            _ = await transport.Initialize(hostSettings, recievers, sendingAddresses, cancellationToken);
+
+            void CriticalErrorAction(string s, Exception e, CancellationToken c)
+            {
+            }
+        }
+
+        class FakeDelayedMessageStore : IDelayedMessageStore
+        {
+            public bool WasInitialized { get; set; }
+
+            public Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default) => Task.FromResult(default(DelayedMessage));
+            public Task<bool> IncrementFailureCount(DelayedMessage entity, CancellationToken cancellationToken = default) => Task.FromResult(default(bool));
+            public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+            {
+                WasInitialized = true;
+                return Task.CompletedTask;
+            }
+            public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default) => Task.FromResult(default(DateTimeOffset?));
+            public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default) => Task.FromResult(default(bool));
+            public Task Store(DelayedMessage entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        class FakeDelayedMessageStoreWithInfrastructure : FakeDelayedMessageStore, IDelayedMessageStoreWithInfrastructure
+        {
+            public bool SetupInfrastructureCalled { get; set; }
+
+            public Task SetupInfrastructure(CancellationToken cancellationToken = default)
+            {
+                SetupInfrastructureCalled = true;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.Msmq.Tests/TestingLoggerSetup.cs
+++ b/src/NServiceBus.Transport.Msmq.Tests/TestingLoggerSetup.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.Transport.Msmq.Tests
+{
+    using Logging;
+    using NUnit.Framework;
+    using Testing;
+
+    [SetUpFixture]
+    public class TestingLoggerSetup
+    {
+        [OneTimeSetUp]
+        public void SetupTestingLogger() => LogManager.Use<TestingLoggerFactory>();
+    }
+}

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/IDelayedMessageStore.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/IDelayedMessageStore.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
     public interface IDelayedMessageStore
     {
         /// <summary>
-        /// Initializes the storage e.g. creates required database artifacts etc.
+        /// Initializes the storage. If the store implements <see cref="IDelayedMessageStoreWithInfrastructure"/>, this method is called first.
         /// </summary>
         /// <param name="endpointName">Name of the endpoint that hosts the delayed delivery storage.</param>
         /// <param name="transactionMode">The transaction mode selected for the transport. The storage implementation should throw an exception if it can't support specified

--- a/src/NServiceBus.Transport.Msmq/DelayedDelivery/IDelayedMessageStoreWithInfrastructure.cs
+++ b/src/NServiceBus.Transport.Msmq/DelayedDelivery/IDelayedMessageStoreWithInfrastructure.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// An <see cref="IDelayedMessageStore" /> that sets up infrastructure.
+    /// </summary>
+    public interface IDelayedMessageStoreWithInfrastructure : IDelayedMessageStore
+    {
+        /// <summary>
+        /// Create tables or other infrastructure. e.g. creates required database artifacts etc.
+        /// Called after <see cref="IDelayedMessageStore.Initialize(string, TransportTransactionMode, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token set if the endpoint begins to shut down while the SetupInfrastructure method is executing.</param>
+        Task SetupInfrastructure(CancellationToken cancellationToken = default);
+    }
+}


### PR DESCRIPTION
Fixes:

- #700

In v2 of the transport, the `IDelayedMessageStore.Initialize(...)` method is only called if the transport is creating queues. This method includes parameters (queue name, transaction mode) which the store needs to do its job.

This PR adds a new interface `IDelayedMessageStoreWithInfrastructure`. This interface implements `IDelayedMessageStore` but adds a new method `SetupInfrastructure(CancellationToken)`.

```csharp
/// <summary>
/// An <see cref="IDelayedMessageStore" /> that sets up infrastructure.
/// </summary>
public interface IDelayedMessageStoreWithInfrastructure : IDelayedMessageStore
{
    /// <summary>
    /// Create tables or other infrastructure. e.g. creates required database artifacts etc.
    /// Called after <see cref="IDelayedMessageStore.Initialize(string, TransportTransactionMode, CancellationToken)"/>.
    /// </summary>
    /// <param name="cancellationToken">The cancellation token set if the endpoint begins to shut down while the SetupInfrastructure method is executing.</param>
    Task SetupInfrastructure(CancellationToken cancellationToken = default);
}
```

If a delayed delivery store implements this interface, then `Initialize(...)` is _always_ called when the transport starts (even if the transport is not creating queues). `SetupInfrastructure(...)` is _only_ called if the transport is creating queues.

If the delayed delivery store only implements `IDelayedMessageStore`, then the behavior is unchanged to preserve backwards compatibility.

The `SqlServerDelayedMessageStore` which is shipped as part of this package has been updated to use the new interface.

## Custom store

If you have developed a custom delayed message store and the transport is configured to create queues (the default), then no change is required. Your custom delayed message store will work as is.

If you have developed a custom delayed message store and have configured the transport to not create queues, then make the following changes:

1. Change your custom delayed message store class to implement `IDelayedMessageStoreWithInfrastructure` instead of `IDelayedMessageStore`.
2. Add an implementation of the `ISetupInfrastructure(...)` method.
3. Move any infrastructure setup code from `Initialize(...)` to `SetupInfrastructure(...)`. If there are any variables created in `Initialize(...)` that are needed in `SetupInfrastructure(...)` store them as fields in the class as `Initialize(...)` is called first.
