### PR TITLE
Don't throw exception when logging

### DIFF
--- a/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
+++ b/src/NServiceBus.Transport.Msmq.TransportTests/NServiceBus.Transport.Msmq.TransportTests.csproj
@@ -18,14 +18,4 @@
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(PkgNServiceBus_TransportTests_Sources)' != ''">
-    <!--
-    The following tests currently fail on the CI build server. They are being excluded from the sources until they are fixed.
-    -->
-    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\When_multiple_messages_are_available_and_concurrency_is_increased_after_pump_started.cs" />
-    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\When_multiple_messages_are_available_and_concurrency_is_increased_and_decreased_after_pump_started.cs" />
-    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\When_multiple_messages_are_available_and_concurrency_is_lowered_after_pump_started.cs" />
-  </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.Transport.Msmq/MsmqQueueCreator.cs
+++ b/src/NServiceBus.Transport.Msmq/MsmqQueueCreator.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.Transport.Msmq
                     }
                     catch (MessageQueueException permissionException) when (permissionException.MessageQueueErrorCode == MessageQueueErrorCode.FormatNameBufferTooSmall)
                     {
-                        Logger.Warn($"The name for queue '{queue.FormatName}' is too long for permissions to be applied. Please consider a shorter endpoint name.", permissionException);
+                        Logger.Warn($"The name for queue '{address}' is too long for permissions to be applied. Please consider a shorter endpoint name.", permissionException);
                     }
                 }
             }


### PR DESCRIPTION
Accessing `queue.FormatName` may throw an exception if the name is too long. If the name is too long, it is likely the code will be in this section where it needs to log. If it attempts to log the message but the log operation raises an exception, then the log isn't written.

This change uses the original string address which will not throw an exception if `queue.FormatName` is too long.